### PR TITLE
feat: Implement authenticated invocation for LB

### DIFF
--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -208,28 +208,26 @@ resource "google_cloud_run_v2_service" "frontend" {
 # Cloud Run Job for Database Migrations
 # Allow public access to the API service via the load balancer
 # Allow public access to the API service via the load balancer
-data "google_iam_policy" "noauth" {
-  binding {
-    role = "roles/run.invoker"
-    members = [
-      "allUsers",
-    ]
-  }
-}
-
-resource "google_cloud_run_v2_service_iam_policy" "api_noauth" {
+# Allow the load balancer's service account to invoke the API service
+resource "google_cloud_run_v2_service_iam_binding" "api_invoker" {
   project  = google_cloud_run_v2_service.api.project
   location = google_cloud_run_v2_service.api.location
   name     = google_cloud_run_v2_service.api.name
-  policy_data = data.google_iam_policy.noauth.policy_data
+  role     = "roles/run.invoker"
+  members = [
+    "serviceAccount:${google_service_account.lb_invoker.email}",
+  ]
 }
 
-# Allow public access to the frontend service via the load balancer
-resource "google_cloud_run_v2_service_iam_policy" "frontend_noauth" {
+# Allow the load balancer's service account to invoke the frontend service
+resource "google_cloud_run_v2_service_iam_binding" "frontend_invoker" {
   project  = google_cloud_run_v2_service.frontend.project
   location = google_cloud_run_v2_service.frontend.location
   name     = google_cloud_run_v2_service.frontend.name
-  policy_data = data.google_iam_policy.noauth.policy_data
+  role     = "roles/run.invoker"
+  members = [
+    "serviceAccount:${google_service_account.lb_invoker.email}",
+  ]
 }
 
 resource "google_cloud_run_v2_job" "migrate" {

--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -207,25 +207,29 @@ resource "google_cloud_run_v2_service" "frontend" {
 
 # Cloud Run Job for Database Migrations
 # Allow public access to the API service via the load balancer
-resource "google_cloud_run_v2_service_iam_binding" "api_invoker" {
+# Allow public access to the API service via the load balancer
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_policy" "api_noauth" {
   project  = google_cloud_run_v2_service.api.project
   location = google_cloud_run_v2_service.api.location
   name     = google_cloud_run_v2_service.api.name
-  role     = "roles/run.invoker"
-  members = [
-    "allUsers",
-  ]
+  policy_data = data.google_iam_policy.noauth.policy_data
 }
 
 # Allow public access to the frontend service via the load balancer
-resource "google_cloud_run_v2_service_iam_binding" "frontend_invoker" {
+resource "google_cloud_run_v2_service_iam_policy" "frontend_noauth" {
   project  = google_cloud_run_v2_service.frontend.project
   location = google_cloud_run_v2_service.frontend.location
   name     = google_cloud_run_v2_service.frontend.name
-  role     = "roles/run.invoker"
-  members = [
-    "allUsers",
-  ]
+  policy_data = data.google_iam_policy.noauth.policy_data
 }
 
 resource "google_cloud_run_v2_job" "migrate" {

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -1,0 +1,5 @@
+resource "google_service_account" "lb_invoker" {
+  account_id   = "finspeed-lb-invoker-${local.environment}"
+  display_name = "Service Account for Load Balancer Invocation"
+  project      = local.project_id
+}

--- a/infra/terraform/networking.tf
+++ b/infra/terraform/networking.tf
@@ -160,6 +160,10 @@ resource "google_compute_backend_service" "api_backend" {
   backend {
     group = google_compute_region_network_endpoint_group.api_neg.id
   }
+
+  service_account = google_service_account.lb_invoker.email
+
+
 }
 
 # Backend service for the Frontend
@@ -174,6 +178,10 @@ resource "google_compute_backend_service" "frontend_backend" {
   backend {
     group = google_compute_region_network_endpoint_group.frontend_neg.id
   }
+
+  service_account = google_service_account.lb_invoker.email
+
+
 }
 
 # URL map to route requests to the backend service


### PR DESCRIPTION
This PR implements the final, secure solution for connecting the Global External HTTPS Load Balancer to the private Cloud Run services, bypassing the organization policy that prevents public invokers. It introduces a dedicated service account for the load balancer and grants it the necessary permissions.