### PR TITLE
fix(ci,infra): Resolve Cloud Run networking issues

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,10 +56,12 @@ jobs:
               --image=$API_IMAGE \
               --region=${{ env.REGION }} \
               --service-account=${{ secrets.WIF_SERVICE_ACCOUNT_STAGING }} \
-              --set-secrets=DATABASE_URL=finspeed-database-url-staging:latest
+              --set-secrets=DATABASE_URL=finspeed-database-url-staging:latest \
+              --vpc-connector=finspeed-vpc-connector-staging \
+              --vpc-egress=private-ranges-only
 
           echo "🔄 Updating and running database migrations..."
-          gcloud run jobs update finspeed-migrate-staging --image=$API_IMAGE --region=${{ env.REGION }} --service-account=${{ secrets.WIF_SERVICE_ACCOUNT_STAGING }}
+          gcloud run jobs update finspeed-migrate-staging --image=$API_IMAGE --region=${{ env.REGION }} --service-account=${{ secrets.WIF_SERVICE_ACCOUNT_STAGING }} --vpc-connector=finspeed-vpc-connector-staging --vpc-egress=private-ranges-only
           gcloud run jobs execute finspeed-migrate-staging --region=${{ env.REGION }} --wait
           echo "🚀 Deploying API to Cloud Run..."
           gcloud run deploy finspeed-api-staging \

--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -263,18 +263,7 @@ resource "google_cloud_run_v2_service" "frontend" {
 #   ]
 # }
 
-# VPC Connector for Cloud Run to access private resources
-resource "google_vpc_access_connector" "connector" {
-  name          = "finspeed-vpc-${local.environment}"
-  region        = local.region
-  ip_cidr_range = "10.8.0.0/28"
-  network       = google_compute_network.vpc_network.name
-  
-  min_instances = 2
-  max_instances = var.environment == "production" ? 10 : 3
 
-  depends_on = [google_project_service.required_apis["vpcaccess.googleapis.com"]]
-}
 
 # Custom domain mapping (optional)
 resource "google_cloud_run_domain_mapping" "api_domain" {

--- a/infra/terraform/networking.tf
+++ b/infra/terraform/networking.tf
@@ -228,3 +228,21 @@ resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   port_range            = "443"
   load_balancing_scheme = "EXTERNAL_MANAGED"
 }
+
+# Serverless VPC Access Connector
+resource "google_vpc_access_connector" "connector" {
+  name          = "finspeed-vpc-connector-${local.environment}"
+  project       = local.project_id
+  region        = local.region
+  network       = google_compute_network.vpc_network.name
+  ip_cidr_range = "10.8.0.0/28"
+
+  depends_on = [google_project_service.vpcaccess_api]
+}
+
+resource "google_project_service" "vpcaccess_api" {
+  service                    = "vpcaccess.googleapis.com"
+  project                    = local.project_id
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}


### PR DESCRIPTION
- Consolidate VPC Access Connector definition into networking.tf.
- Remove duplicate connector from cloud_run.tf.
- Configure Cloud Run services and migration job to use the VPC connector.
- This ensures Cloud Run can access the private Cloud SQL database.