### PR TITLE
fix(ci,infra): Correct VPC connector name mismatch

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -57,11 +57,11 @@ jobs:
               --region=${{ env.REGION }} \
               --service-account=${{ secrets.WIF_SERVICE_ACCOUNT_STAGING }} \
               --set-secrets=DATABASE_URL=finspeed-database-url-staging:latest \
-              --vpc-connector=finspeed-vpc-connector-staging \
+              --vpc-connector=finspeed-vpc-staging \
               --vpc-egress=private-ranges-only
 
           echo "🔄 Updating and running database migrations..."
-          gcloud run jobs update finspeed-migrate-staging --image=$API_IMAGE --region=${{ env.REGION }} --service-account=${{ secrets.WIF_SERVICE_ACCOUNT_STAGING }} --vpc-connector=finspeed-vpc-connector-staging --vpc-egress=private-ranges-only
+          gcloud run jobs update finspeed-migrate-staging --image=$API_IMAGE --region=${{ env.REGION }} --service-account=${{ secrets.WIF_SERVICE_ACCOUNT_STAGING }} --vpc-connector=finspeed-vpc-staging --vpc-egress=private-ranges-only
           gcloud run jobs execute finspeed-migrate-staging --region=${{ env.REGION }} --wait
           echo "🚀 Deploying API to Cloud Run..."
           gcloud run deploy finspeed-api-staging \

--- a/infra/terraform/networking.tf
+++ b/infra/terraform/networking.tf
@@ -231,7 +231,7 @@ resource "google_compute_global_forwarding_rule" "forwarding_rule" {
 
 # Serverless VPC Access Connector
 resource "google_vpc_access_connector" "connector" {
-  name          = "finspeed-vpc-connector-${local.environment}"
+  name          = "finspeed-vpc-${local.environment}"
   project       = local.project_id
   region        = local.region
   network       = google_compute_network.vpc_network.name


### PR DESCRIPTION
- Aligns the VPC connector name in Terraform and the GitHub workflow.
- Resolves the 'connector does not exist' error during job execution.