### PR TITLE
fix(ci): Ensure Terraform workspace exists

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -98,7 +98,7 @@ jobs:
         id: get_iap_client_id
         run: |
           terraform init -backend-config="bucket=finspeed-tfstate-${{ env.PROJECT_ID_STAGING }}" -reconfigure
-          terraform workspace select staging
+          terraform workspace select staging || terraform workspace new staging
           echo "iap_client_id=$(terraform output -raw iap_client_id)" >> $GITHUB_ENV
         working-directory: ./infra/terraform
 


### PR DESCRIPTION
- Makes the workspace selection step idempotent by creating the workspace if it doesn't exist.
- This resolves the 'workspace doesn't exist' error during terraform init.