### PR TITLE
revert: Remove workflow bootstrap and restore TF resources

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,21 +46,7 @@ jobs:
           gcloud storage buckets describe gs://finspeed-tfstate-${{ env.PROJECT_ID_STAGING }} || \
           gcloud storage buckets create gs://finspeed-tfstate-${{ env.PROJECT_ID_STAGING }} --project=${{ env.PROJECT_ID_STAGING }} --location=${{ env.REGION }} --uniform-bucket-level-access
 
-      - name: 'Bootstrap GitHub Actions Service Account'
-        id: create_sa
-        run: |
-          gcloud iam service-accounts describe github-actions-staging@${{ env.PROJECT_ID_STAGING }}.iam.gserviceaccount.com || \
-          gcloud iam service-accounts create github-actions-staging \
-            --display-name="GitHub Actions Service Account (staging)" \
-            --project=${{ env.PROJECT_ID_STAGING }}
 
-      - name: 'Bootstrap IAM Permissions'
-        run: |
-          SA_EMAIL="github-actions-staging@${{ env.PROJECT_ID_STAGING }}.iam.gserviceaccount.com"
-          gcloud projects add-iam-policy-binding ${{ env.PROJECT_ID_STAGING }} --member="serviceAccount:$SA_EMAIL" --role="roles/iam.serviceAccountAdmin" --condition=None
-          gcloud projects add-iam-policy-binding ${{ env.PROJECT_ID_STAGING }} --member="serviceAccount:$SA_EMAIL" --role="roles/iap.admin" --condition=None
-          gcloud projects add-iam-policy-binding ${{ env.PROJECT_ID_STAGING }} --member="serviceAccount:$SA_EMAIL" --role="roles/compute.securityAdmin" --condition=None
-          gcloud projects add-iam-policy-binding ${{ env.PROJECT_ID_STAGING }} --member="serviceAccount:$SA_EMAIL" --role="roles/iam.workloadIdentityUser" --condition=None
 
       - name: Terraform Apply
         run: |

--- a/infra/terraform/workload_identity.tf
+++ b/infra/terraform/workload_identity.tf
@@ -56,6 +56,62 @@ resource "google_iam_workload_identity_pool_provider" "github_provider" {
   attribute_condition = "assertion.repository == '${var.github_repository}' && (assertion.ref == 'refs/heads/main' || assertion.ref == 'refs/heads/develop' || assertion.ref_type == 'tag' || assertion.ref == 'refs/heads/feat/p1-local-dev-setup')"
 }
 
+# Create service account for GitHub Actions
+resource "google_service_account" "github_actions" {
+  account_id   = "github-actions-${local.environment}"
+  display_name = "GitHub Actions Service Account (${local.environment})"
+  description  = "Service account for GitHub Actions CI/CD pipeline"
+  project      = local.project_id
+}
+
+# Allow GitHub Actions to impersonate the service account
+resource "google_service_account_iam_member" "github_actions_workload_identity" {
+  service_account_id = google_service_account.github_actions.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${local.workload_identity_pool_name}/attribute.repository/${var.github_repository}"
+}
+
+# Allow the project owner to impersonate the service account for local testing
+resource "google_service_account_iam_member" "github_actions_user_token_creator" {
+  service_account_id = google_service_account.github_actions.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "user:${var.project_owner_email}"
+}
+
+# Allow GitHub Actions to generate access tokens for the service account
+resource "google_service_account_iam_binding" "github_actions_token_creator" {
+  service_account_id = google_service_account.github_actions.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "principalSet://iam.googleapis.com/${local.workload_identity_pool_name}/attribute.repository/${var.github_repository}"
+  ]
+}
+
+# Grant necessary permissions to the service account
+resource "google_project_iam_member" "github_actions_permissions" {
+  for_each = toset([
+    "roles/run.admin",                    # Deploy Cloud Run services
+    "roles/cloudsql.admin",              # Manage Cloud SQL
+    "roles/secretmanager.admin",         # Manage secrets
+    "roles/monitoring.admin",            # Manage monitoring
+    "roles/compute.networkAdmin",        # Manage VPC and networking
+    "roles/iam.serviceAccountUser",
+    "roles/cloudsql.client",
+    "roles/iam.serviceAccountTokenCreator", # Create access tokens for impersonation
+    "roles/storage.admin",               # Access Cloud Storage (for Terraform state)
+    "roles/artifactregistry.admin",      # Push/pull container images
+    "roles/cloudbuild.builds.builder",   # Build containers
+    "roles/iam.serviceAccountAdmin",     # Create and manage service accounts
+    "roles/iap.admin",                   # Manage IAP settings
+    "roles/compute.securityAdmin"      # Manage SSL certificates and security policies
+  ])
+
+  project = local.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.github_actions.email}"
+}
+
 # Output important values for GitHub Actions configuration
 output "workload_identity_provider" {
   description = "The full identifier of the Workload Identity Provider"
@@ -64,7 +120,7 @@ output "workload_identity_provider" {
 
 output "github_actions_service_account" {
   description = "Email of the service account for GitHub Actions"
-  value       = "github-actions-staging@${local.project_id}.iam.gserviceaccount.com"
+  value       = google_service_account.github_actions.email
 }
 
 output "workload_identity_pool_id" {


### PR DESCRIPTION
- Reverts the flawed gcloud bootstrap steps from the workflow.
- Restores the service account and IAM resources in the Terraform configuration.
- This prepares the codebase for a one-time manual 'terraform apply' by a project owner to correctly bootstrap the CI/CD environment.