### PR TITLE
fix(terraform): add create_before_destroy lifecycle to SSL cert

### DIFF
--- a/infra/terraform/networking.tf
+++ b/infra/terraform/networking.tf
@@ -206,6 +206,9 @@ resource "google_compute_url_map" "url_map" {
 
 # Managed SSL certificate for the custom domain
 resource "google_compute_managed_ssl_certificate" "ssl_certificate" {
+  lifecycle {
+    create_before_destroy = true
+  }
   count = var.domain_name != "" && var.enable_ssl ? 1 : 0
   name  = "finspeed-ssl-cert-${local.environment}"
   managed {

--- a/infra/terraform/staging/main.tf
+++ b/infra/terraform/staging/main.tf
@@ -8,6 +8,7 @@ module "finspeed_infra" {
   source = "../"
 
   # Pass variables from terraform.tfvars to the module
+  # Final validation of the PR workflow.
   project_id                       = var.project_id
   environment                      = var.environment
   region                           = var.region


### PR DESCRIPTION
This prevents 'resourceInUseByAnotherResource' errors when updating domains on the GCP load balancer by ensuring Terraform creates the new certificate before deleting the old one.