### PR TITLE
Fix: Remove unused time import in orders.go

### DIFF
--- a/api/internal/handlers/orders.go
+++ b/api/internal/handlers/orders.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"


### PR DESCRIPTION
Fixes Go build error during staging deployment by removing unused time import from orders.go handler.