### PR TITLE
fix: resolve duplicate google_project data source conflict

### DIFF
--- a/infra/terraform/api_gateway.tf
+++ b/infra/terraform/api_gateway.tf
@@ -111,10 +111,5 @@ resource "google_project_iam_member" "cloudbuild_sa_permissions" {
   
   project = local.project_id
   role    = each.value
-  member  = "serviceAccount:${data.google_project.current.number}@cloudbuild.gserviceaccount.com"
-}
-
-# Get current project info for Cloud Build service account
-data "google_project" "current" {
-  project_id = local.project_id
+  member  = "serviceAccount:${data.google_project.current[0].number}@cloudbuild.gserviceaccount.com"
 }

--- a/infra/terraform/static_hosting.tf
+++ b/infra/terraform/static_hosting.tf
@@ -31,9 +31,9 @@ resource "google_storage_bucket" "static_website" {
   labels = local.common_labels
 }
 
-# Project data (for Cloud CDN fill service account in prod)
+# Project data (for Cloud CDN fill service account in prod and API Gateway Cloud Build)
 data "google_project" "current" {
-  count      = var.use_static_hosting && var.environment == "production" ? 1 : 0
+  count      = (var.use_static_hosting && var.environment == "production") || var.allow_public_api ? 1 : 0
   project_id = local.project_id
 }
 
@@ -141,7 +141,7 @@ resource "google_compute_url_map" "url_map_with_static" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy       = true
     create_before_destroy = true
   }
 }


### PR DESCRIPTION
- Modified static_hosting.tf data source condition to include allow_public_api
- Removed duplicate data source from api_gateway.tf
- Updated api_gateway.tf to reference data.google_project.current[0] for Cloud Build SA