### PR TITLE
fix: add import block for existing API Gateway Cloud Function

### DIFF
--- a/infra/terraform/api_gateway.tf
+++ b/infra/terraform/api_gateway.tf
@@ -113,3 +113,9 @@ resource "google_project_iam_member" "cloudbuild_sa_permissions" {
   role    = each.value
   member  = "serviceAccount:${data.google_project.current[0].number}@cloudbuild.gserviceaccount.com"
 }
+
+# Import existing Cloud Function if it was created outside Terraform
+import {
+  to = google_cloudfunctions2_function.api_gateway[0]
+  id = "projects/finspeed-staging-st/locations/asia-south2/functions/finspeed-api-gateway-staging"
+}


### PR DESCRIPTION
- Import existing finspeed-api-gateway-staging function into Terraform state
- Resolves 'Resource already exists' error during deployment
- Allows Terraform to manage the previously created function