### PR TITLE
fix: add missing Cloud Build service account IAM roles

### DIFF
--- a/infra/terraform/api_gateway.tf
+++ b/infra/terraform/api_gateway.tf
@@ -106,7 +106,10 @@ resource "google_project_iam_member" "cloudbuild_sa_permissions" {
   for_each = var.allow_public_api ? toset([
     "roles/cloudfunctions.developer",
     "roles/storage.admin",
-    "roles/artifactregistry.writer"
+    "roles/artifactregistry.writer",
+    "roles/cloudbuild.builds.builder",
+    "roles/source.reader",
+    "roles/logging.logWriter"
   ]) : toset([])
   
   project = local.project_id


### PR DESCRIPTION
- Add roles/cloudbuild.builds.builder for build execution
- Add roles/source.reader for source code access
- Add roles/logging.logWriter for build logs
- Should resolve Cloud Function build permission errors