### PR TITLE
feat(admin): expand dashboard with material 3 pages

### DIFF
--- a/admin-app/src/app/admin/analytics/page.tsx
+++ b/admin-app/src/app/admin/analytics/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export default function AnalyticsPage() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-3xl font-bold text-[color:var(--md-sys-color-on-surface)] mb-4">Analytics</h1>
+      <div className="md-surface-container-highest rounded-lg p-6">
+        <p className="text-[color:var(--md-sys-color-on-surface-variant)]">Analytics dashboard coming soon.</p>
+      </div>
+    </div>
+  );
+}

--- a/admin-app/src/app/admin/categories/new/page.tsx
+++ b/admin-app/src/app/admin/categories/new/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+export default function NewCategoryPage() {
+  return (
+    <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-3xl font-bold text-[color:var(--md-sys-color-on-surface)] mb-4">Add Category</h1>
+      <form className="space-y-4 md-surface-container-highest rounded-lg p-6">
+        <div>
+          <label className="block text-sm font-medium text-[color:var(--md-sys-color-on-surface)]">Name</label>
+          <input type="text" className="mt-1 block w-full rounded-md border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] focus:border-[color:var(--md-sys-color-primary)] focus:ring-[color:var(--md-sys-color-primary)]" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-[color:var(--md-sys-color-on-surface)]">Slug</label>
+          <input type="text" className="mt-1 block w-full rounded-md border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] focus:border-[color:var(--md-sys-color-primary)] focus:ring-[color:var(--md-sys-color-primary)]" />
+        </div>
+        <button type="button" className="mt-4 inline-flex items-center rounded-lg px-4 py-2 bg-[color:var(--md-sys-color-primary)] text-[color:var(--md-sys-color-on-primary)] hover:opacity-90">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/admin-app/src/app/admin/dashboard/page.tsx
+++ b/admin-app/src/app/admin/dashboard/page.tsx
@@ -1,10 +1,1 @@
-import React from 'react';
-
-export default function AdminDashboardPage() {
-  return (
-    <div>
-      <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
-      <p className="mt-4 text-gray-600">Welcome to the Finspeed admin dashboard. Here you can manage products, categories, users, and more.</p>
-    </div>
-  );
-}
+export { default } from '../page';

--- a/admin-app/src/app/admin/orders/page.tsx
+++ b/admin-app/src/app/admin/orders/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export default function OrdersPage() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-3xl font-bold text-[color:var(--md-sys-color-on-surface)] mb-4">Orders</h1>
+      <div className="md-surface-container-highest rounded-lg p-6">
+        <p className="text-[color:var(--md-sys-color-on-surface-variant)]">No orders to display.</p>
+      </div>
+    </div>
+  );
+}

--- a/admin-app/src/app/admin/page.tsx
+++ b/admin-app/src/app/admin/page.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { ShoppingBagIcon, UserGroupIcon, ChartBarIcon, CogIcon, SwatchIcon } from '@heroicons/react/24/outline';
+import {
+  ShoppingBagIcon,
+  TagIcon,
+  UserGroupIcon,
+  ShoppingCartIcon,
+  ChartBarIcon,
+  CogIcon,
+  SwatchIcon,
+} from '@heroicons/react/24/outline';
 
 export default function AdminPage() {
   const router = useRouter();
@@ -15,8 +23,9 @@ export default function AdminPage() {
 
   const quickActions = [
     { name: 'Add Product', href: '/admin/products/new', icon: ShoppingBagIcon },
-    { name: 'View Orders', href: '/admin/orders', icon: ShoppingBagIcon },
+    { name: 'Add Category', href: '/admin/categories/new', icon: TagIcon },
     { name: 'Manage Users', href: '/admin/users', icon: UserGroupIcon },
+    { name: 'View Orders', href: '/admin/orders', icon: ShoppingCartIcon },
     { name: 'Analytics', href: '/admin/analytics', icon: ChartBarIcon },
     { name: 'Settings', href: '/admin/settings', icon: CogIcon },
   ];
@@ -32,7 +41,7 @@ export default function AdminPage() {
                 Dashboard
               </h1>
               <p className="mt-2 text-[color:var(--md-sys-color-on-surface-variant)]">
-                Welcome back! Here's what's happening with your store.
+                Welcome back! Here&apos;s what&apos;s happening with your store.
               </p>
             </div>
             <div className="mt-4 md:mt-0">
@@ -84,7 +93,7 @@ export default function AdminPage() {
           <h2 className="text-lg font-medium text-[color:var(--md-sys-color-on-surface)] mb-4">
             Quick Actions
           </h2>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
             {quickActions.map((action) => {
               const Icon = action.icon;
               return (

--- a/admin-app/src/app/admin/products/new/page.tsx
+++ b/admin-app/src/app/admin/products/new/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+export default function NewProductPage() {
+  return (
+    <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-3xl font-bold text-[color:var(--md-sys-color-on-surface)] mb-4">Add Product</h1>
+      <form className="space-y-4 md-surface-container-highest rounded-lg p-6">
+        <div>
+          <label className="block text-sm font-medium text-[color:var(--md-sys-color-on-surface)]">Title</label>
+          <input type="text" className="mt-1 block w-full rounded-md border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] focus:border-[color:var(--md-sys-color-primary)] focus:ring-[color:var(--md-sys-color-primary)]" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-[color:var(--md-sys-color-on-surface)]">Price</label>
+          <input type="number" className="mt-1 block w-full rounded-md border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] focus:border-[color:var(--md-sys-color-primary)] focus:ring-[color:var(--md-sys-color-primary)]" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-[color:var(--md-sys-color-on-surface)]">SKU</label>
+          <input type="text" className="mt-1 block w-full rounded-md border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] focus:border-[color:var(--md-sys-color-primary)] focus:ring-[color:var(--md-sys-color-primary)]" />
+        </div>
+        <button type="button" className="mt-4 inline-flex items-center rounded-lg px-4 py-2 bg-[color:var(--md-sys-color-primary)] text-[color:var(--md-sys-color-on-primary)] hover:opacity-90">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/admin-app/src/app/admin/settings/page.tsx
+++ b/admin-app/src/app/admin/settings/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+export default function SettingsPage() {
+  return (
+    <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-3xl font-bold text-[color:var(--md-sys-color-on-surface)] mb-4">Settings</h1>
+      <form className="space-y-4 md-surface-container-highest rounded-lg p-6">
+        <div>
+          <label className="block text-sm font-medium text-[color:var(--md-sys-color-on-surface)]">Store Name</label>
+          <input type="text" className="mt-1 block w-full rounded-md border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] focus:border-[color:var(--md-sys-color-primary)] focus:ring-[color:var(--md-sys-color-primary)]" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-[color:var(--md-sys-color-on-surface)]">Support Email</label>
+          <input type="email" className="mt-1 block w-full rounded-md border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] focus:border-[color:var(--md-sys-color-primary)] focus:ring-[color:var(--md-sys-color-primary)]" />
+        </div>
+        <button type="button" className="mt-4 inline-flex items-center rounded-lg px-4 py-2 bg-[color:var(--md-sys-color-primary)] text-[color:var(--md-sys-color-on-primary)] hover:opacity-90">Save</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expand dashboard quick actions to cover more admin tasks
- add material 3 styled placeholders for orders, analytics, settings, and creation forms
- reuse main dashboard component for /admin/dashboard route

## Testing
- `cd admin-app && pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68acc8a4f9bc832088906fd251308cd9