### PR TITLE
fix(web): gate the distributor portal and fail closed on analytics consent

### DIFF
--- a/apps/web/src/design/features/distributor/Auth.jsx
+++ b/apps/web/src/design/features/distributor/Auth.jsx
@@ -79,8 +79,8 @@ function DistAuth({ onEnter }) {
               <h1 style={{ font:'var(--fw-bold) var(--fs-3xl)/1 var(--font-display)', letterSpacing:'-0.02em', color:'var(--ink-900)', margin:'0 0 var(--space-2)' }}>Distributor sign in</h1>
               <p style={{ font:'var(--text-body-sm)', color:'var(--text-muted)', margin:'0 0 var(--space-6)' }}>Access pricing, order builder and invoices.</p>
               <form onSubmit={submit} style={{ display:'flex', flexDirection:'column', gap:'var(--space-4)' }}>
-                <Input label="Dealer ID or email" placeholder="ravi@ravistores.in" defaultValue="ravi@ravistores.in" autoComplete="username" required iconLeft={<i data-lucide="building-2" style={{width:17,height:17}}></i>} />
-                <Input label="Password" type="password" placeholder="••••••••" defaultValue="password" autoComplete="current-password" required iconLeft={<i data-lucide="lock" style={{width:17,height:17}}></i>} />
+                <Input label="Dealer ID or email" placeholder="ravi@ravistores.in" autoComplete="username" required iconLeft={<i data-lucide="building-2" style={{width:17,height:17}}></i>} />
+                <Input label="Password" type="password" placeholder="••••••••" autoComplete="current-password" required iconLeft={<i data-lucide="lock" style={{width:17,height:17}}></i>} />
                 <div className="dist-auth-options" style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginTop:'calc(-1 * var(--space-1))' }}>
                   <label style={{ display:'flex', alignItems:'center', gap:8, cursor:'pointer', font:'var(--fw-regular) var(--fs-sm)/1 var(--font-body)', color:'var(--text-body)' }}>
                     <input type="checkbox" defaultChecked style={{ accentColor:'var(--brand)', width:16, height:16 }} /> Keep me signed in
@@ -91,6 +91,10 @@ function DistAuth({ onEnter }) {
                   <Button type="submit" variant="primary" size="lg" full iconRight={<i data-lucide="arrow-right" style={{width:18,height:18}}></i>}>Enter portal</Button>
                 </div>
               </form>
+              <p style={{ display:'flex', gap:8, alignItems:'flex-start', font:'var(--fw-regular) var(--fs-xs)/1.5 var(--font-body)', color:'var(--text-faint)', margin:'var(--space-4) 0 0' }}>
+                <i data-lucide="info" style={{ width:15, height:15, marginTop:2, flex:'none' }}></i>
+                Preview only. Credentials are not verified and no live dealer account is opened. The portal shows sample pricing and orders that stay in this browser.
+              </p>
             </React.Fragment>
           ) : (
             <React.Fragment>

--- a/apps/web/src/design/features/distributor/DistributorApp.jsx
+++ b/apps/web/src/design/features/distributor/DistributorApp.jsx
@@ -54,7 +54,12 @@ export default function DistributorApp() {
   const [toast, setToast] = React.useState(null);
   const [justPlaced, setJustPlaced] = React.useState(null);
   const toastTimer = React.useRef(null);
-  const signedOut = normalizedPath === '/distributor/sign-in';
+  // The portal is gated on an in-session sign-in rather than on the current
+  // path, so a deep link cannot render dealer pricing to a visitor who never
+  // signed in. A reload returns to the sign-in screen by design.
+  const [authenticated, setAuthenticated] = React.useState(false);
+  const atSignIn = normalizedPath === '/distributor/sign-in';
+  const signedOut = !authenticated;
 
   useLucideIcons();
 
@@ -147,8 +152,11 @@ export default function DistributorApp() {
   }
 
   if (signedOut) {
-    return <Auth onEnter={() => navigate('/distributor')} />;
+    if (!atSignIn) return <Navigate to="/distributor/sign-in" replace />;
+    return <Auth onEnter={() => { setAuthenticated(true); navigate('/distributor'); }} />;
   }
+
+  if (atSignIn) return <Navigate to="/distributor" replace />;
 
   const [title, subtitle] = headings[route];
   const orderCount = Object.keys(order).length;
@@ -156,7 +164,7 @@ export default function DistributorApp() {
 
   return (
     <div className="dist-app-shell" style={{ display: 'flex', minHeight: '100vh', background: 'var(--bg-page)' }}>
-      <Sidebar route={route} onNav={setRoute} orderCount={orderCount} onSignOut={() => navigate('/distributor/sign-in')} />
+      <Sidebar route={route} onNav={setRoute} orderCount={orderCount} onSignOut={() => { setAuthenticated(false); navigate('/distributor/sign-in'); }} />
       <div className="dist-main" style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
         <Topbar title={title} subtitle={subtitle} query={query} onSearch={setQuery} />
         <div className="dist-route-body" style={{ flex: 1, minWidth: 0 }}>

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -46,7 +46,9 @@ type AnalyticsPayload = {
 
 const dataLayer: Array<{ event: EventName; payload: AnalyticsPayload }> = [];
 
-let consentGranted = true;
+// Fail closed: nothing reaches the data layer until a stored or freshly given
+// consent decision is applied through setConsent().
+let consentGranted = false;
 
 export function setConsent(granted: boolean) {
   consentGranted = granted;

--- a/apps/web/src/lib/consent.ts
+++ b/apps/web/src/lib/consent.ts
@@ -25,11 +25,25 @@ function readStored(): ConsentState {
   return memoryConsent;
 }
 
+function syncAnalyticsConsent() {
+  setConsent(memoryConsent === 'granted');
+}
+
+// Apply the stored decision as soon as this module loads on the client.
+// The analytics module defaults to denied, so without this a returning
+// visitor who accepted would be silently untracked — and a decision made in
+// another tab would never reach this one.
+if (typeof window !== 'undefined') {
+  readStored();
+  syncAnalyticsConsent();
+}
+
 function subscribe(listener: () => void) {
   listeners.add(listener);
 
   const syncStoredConsent = () => {
     readStored();
+    syncAnalyticsConsent();
     listener();
   };
   window.addEventListener('storage', syncStoredConsent);

--- a/apps/web/tests/distributor-access.spec.ts
+++ b/apps/web/tests/distributor-access.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const PORTAL_PATHS = [
+  '/distributor',
+  '/distributor/price-list',
+  '/distributor/order-builder',
+  '/distributor/orders',
+  '/distributor/invoices',
+  '/distributor/account',
+  '/distributor/support',
+];
+
+// Chrome exposes the price table as a layout table, so `columnheader` does not
+// resolve — assert on the cell itself.
+const DEALER_PRICE_HEADER = (page: Page) => page.locator('th', { hasText: 'Distributor price' });
+
+async function prepare(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('finspeed-consent', 'denied');
+  });
+}
+
+async function signIn(page: Page) {
+  await page.goto('/distributor/sign-in');
+  await page.getByLabel('Dealer ID or email').fill('ravi@ravistores.in');
+  await page.getByLabel('Password').fill('preview');
+  await page.getByRole('button', { name: 'Enter portal' }).click();
+  await expect(page).toHaveURL(/\/distributor$/);
+}
+
+test.describe('distributor portal access', () => {
+  test('every portal path redirects to sign in without a session', async ({ page }) => {
+    await prepare(page);
+    for (const path of PORTAL_PATHS) {
+      await page.goto(path);
+      await expect(page).toHaveURL(/\/distributor\/sign-in$/);
+      await expect(page.getByRole('heading', { level: 1, name: 'Distributor sign in' })).toBeVisible();
+    }
+  });
+
+  test('dealer cost prices and margins stay hidden until sign in', async ({ page }) => {
+    await prepare(page);
+    await page.goto('/distributor/price-list');
+
+    await expect(DEALER_PRICE_HEADER(page)).toHaveCount(0);
+    await expect(page.getByText('37.9%')).toHaveCount(0);
+    await expect(page.getByText(/Avg distributor margin/)).toHaveCount(0);
+  });
+
+  test('the sign-in screen states that credentials are not verified', async ({ page }) => {
+    await prepare(page);
+    await page.goto('/distributor/sign-in');
+
+    await expect(page.getByText(/Preview only\. Credentials are not verified/i)).toBeVisible();
+    await expect(page.getByLabel('Dealer ID or email')).toHaveValue('');
+    await expect(page.getByLabel('Password')).toHaveValue('');
+  });
+
+  test('signing in opens the portal and signing out closes it again', async ({ page }) => {
+    await prepare(page);
+    await signIn(page);
+
+    // In-app navigation only — the session lives in memory, so a full page
+    // load is expected to drop it (covered by the reload test below).
+    await page.getByRole('button', { name: 'Price list' }).click();
+    await expect(page).toHaveURL(/\/distributor\/price-list$/);
+    await expect(DEALER_PRICE_HEADER(page)).toBeVisible();
+    await expect(page.getByText('37.9%')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Sign out' }).click();
+    await expect(page).toHaveURL(/\/distributor\/sign-in$/);
+    await expect(DEALER_PRICE_HEADER(page)).toHaveCount(0);
+  });
+
+  test('a reload drops the session rather than leaving the portal open', async ({ page }) => {
+    await prepare(page);
+    await signIn(page);
+
+    await page.reload();
+    await expect(page).toHaveURL(/\/distributor\/sign-in$/);
+  });
+});

--- a/specs/notes/plans/web/WEB-036.md
+++ b/specs/notes/plans/web/WEB-036.md
@@ -1,0 +1,67 @@
+# Plan — WEB-036
+
+- Context:
+  Two defects live on `www.finspeed.online`, both found while assessing production readiness.
+
+  The distributor portal gated on the current path rather than on a session:
+  `DistributorApp.jsx` computed `signedOut` as `normalizedPath === '/distributor/sign-in'`,
+  so navigating directly to `/distributor` — or any sub-route — rendered the full portal
+  without ever passing through sign-in. Dealer cost prices, margins, order history and
+  invoices were reachable by URL alone. The sign-in form accepted anything
+  (`function submit(e){ e.preventDefault(); onEnter && onEnter(); }`) and shipped with a
+  prefilled dealer ID and password.
+
+  Separately, `analytics.ts` initialised `consentGranted = true` and `setConsent()` was only
+  ever called from a banner click, so events reached `window.dataLayer` before the visitor
+  answered — the failure `WEB-020.md:44` explicitly forbids. Because nothing applied stored
+  consent on load, a stored `denied` was also ignored on every subsequent page load: a
+  visitor who declined was tracked anyway on their next visit.
+- Goals:
+  - Gate every `/distributor/*` path on an in-session sign-in.
+  - Stop presenting the distributor sign-in as real authentication.
+  - Make analytics fail closed and honour a stored decision in both directions.
+  - Cover the gate with contract tests; it had none.
+- Risks:
+  - The gate does not secure the underlying data. `distributor.js` is still compiled into the
+    public client bundle, so cost prices and margins remain readable from the JS regardless.
+    Moving that behind an authenticated server route needs a backend and is out of scope here.
+  - The session is held in memory, so a full page load returns to sign-in. This is deliberate
+    for a portal with no real authentication, but it means the portal is usable only through
+    in-app navigation.
+
+## Steps
+1. Replace the path-based `signedOut` in `DistributorApp.jsx` with in-session state. Redirect
+   unauthenticated requests on any portal path to `/distributor/sign-in`; redirect an
+   authenticated visitor away from the sign-in path; clear the session on sign-out.
+2. Remove the prefilled dealer ID and password from `distributor/Auth.jsx` so the existing
+   `required` attributes force input, and add a preview notice matching the storefront's
+   existing wording in `storefront/Auth.jsx:207`.
+3. Default `consentGranted` to `false` in `analytics.ts`.
+4. Apply the stored decision in `consent.ts` on client load and on the cross-tab `storage`
+   event, so a persisted grant is honoured and a persisted denial survives a reload.
+5. Add `apps/web/tests/distributor-access.spec.ts` covering all seven portal paths.
+
+## Execution Checklist
+- [x] Every `/distributor/*` path redirects to sign-in without a session.
+- [x] Dealer price and margin columns absent before sign-in.
+- [x] Sign-in states that credentials are not verified; no prefilled values.
+- [x] Analytics fails closed; stored grant and denial both honoured.
+- [x] Contract tests added and passing (5 tests).
+- [ ] Proof artefacts captured.
+- [ ] Telemetry refreshed.
+- [ ] Slice parked.
+
+## Follow-ups (not in this slice)
+- Move `distributor.js` pricing behind an authenticated server route. Until then the gate is
+  presentation, not access control.
+- Add a preview disclaimer to distributor PO placement. `DistributorApp.jsx` still toasts
+  `Order PO-… placed · Net-30` with nothing behind it, unlike the honest storefront checkout.
+- Add a privacy link to the consent banner once a `/privacy` route exists.
+- The distributor price table is exposed to Chrome as a layout table, so `columnheader` does
+  not resolve and screen readers get no column associations. Not covered by the axe suite.
+
+## Artefact References
+- Gate: `apps/web/src/design/features/distributor/DistributorApp.jsx`.
+- Sign-in: `apps/web/src/design/features/distributor/Auth.jsx`.
+- Consent: `apps/web/src/lib/analytics.ts`, `apps/web/src/lib/consent.ts`.
+- Tests: `apps/web/tests/distributor-access.spec.ts`.

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -197,6 +197,12 @@
           "domain": "web",
           "title": "Comprehensive bespoke configurator",
           "status": "active"
+        },
+        {
+          "id": "WEB-036",
+          "domain": "web",
+          "title": "Distributor portal access gate and consent fail-closed",
+          "status": "active"
         }
       ]
     }


### PR DESCRIPTION
## What

Two live defects on `www.finspeed.online`, plus regression coverage for the first.

### 1. The distributor portal was ungated

The gate tested the current path (`normalizedPath === '/distributor/sign-in'`), not a session. Navigating directly to `/distributor` — or any sub-route — rendered the full portal without ever passing through sign-in, exposing dealer cost prices, margins, order history and invoices. The sign-in form itself was `function submit(e){ e.preventDefault(); onEnter && onEnter(); }`, with prefilled dealer ID and password.

Now gated on in-session state: unauthenticated requests to any portal path redirect to sign-in, sign-out clears the session, and a reload drops it. Prefilled credentials removed so the existing `required` attributes actually force input, and the screen states that credentials are not verified — matching the storefront's existing preview notice.

**This does not secure the underlying data.** `distributor.js` is still compiled into the public client bundle, so the cost prices and margins remain readable from the JS regardless of the gate. Moving that behind an authenticated server route is separate work. What this changes is that the portal no longer renders to casual visitors and no longer presents itself as a real login.

### 2. Analytics fired before consent

`analytics.ts` initialised `consentGranted = true`, and `setConsent()` was only ever called from a banner click — so events reached `window.dataLayer` before the visitor answered. This is the failure `specs/notes/plans/web/WEB-020.md:44` explicitly forbids.

Beyond the reported defect: because nothing applied stored consent on load, **a stored `denied` was ignored on every subsequent page load** — a returning visitor who declined was tracked anyway. Now defaults to denied, and `consent.ts` applies the stored decision on client load and on the cross-tab `storage` event, closing it in both directions.

## Verification

- **22/22** targeted tests pass — new spec plus consent, a11y, auth, checkout, account, newsletter, dealer-locator
- ESLint: **0 errors**, 37 warnings (unchanged)
- `next build`: passes, 14 static pages
- `node --test`: 24/24

Full suite is **59 passed / 9 failed**. The 9 failures were confirmed pre-existing by reverting this branch's source changes to `a401e6d` and re-running — the same specs fail there (10, so one fewer with these changes). They are the in-flight WEB-035 work: `configurator.spec.ts` and `contract.spec.ts` expect `mako-shark-27-5-geared-r01-w1600.webp` while the app serves `mako-disc-front-21-catalog-none-r01-w1600.webp`, i.e. test expectations updated ahead of asset registration. Unrelated to this diff.

## Notes for review

- **The commit message omits the active slice ID.** `verify-commit-msg.mjs` requires it and `active-slice.json` holds `WEB-035`, but this isn't WEB-035 work — tagging it that way would file a security fix under the configurator slice permanently. Happy to amend or register a slice, whichever you prefer.
- **CI `guard` will fail on this branch for an unrelated reason.** `verify-active-slice.mjs:49-52` exits 1 when `specs/working-memory/active-slice.json` is missing, and `.gitignore:11` excludes it, so the job cannot pass on a clean checkout. That also gates `deploy-web`. Nothing here changes that either way.
- **Incidental finding, not addressed:** `getByRole('columnheader')` resolves to zero on the distributor price table despite 7 `<th>` elements — Chrome treats it as a layout table, so screen readers get no column associations. Pre-existing; the axe suite doesn't cover that table. The new spec works around it with a `th` text locator.
- **Not included:** a privacy link on the consent banner (no `/privacy` route exists yet, so it would 404), and a preview disclaimer on distributor PO placement, which still toasts "Order PO-… placed · Net-30" with nothing behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
