### PR TITLE
docs(web): WEB-036 proof bundle, checklist close, and ledger flip

### DIFF
--- a/specs/notes/plans/web/WEB-036.md
+++ b/specs/notes/plans/web/WEB-036.md
@@ -47,9 +47,9 @@
 - [x] Sign-in states that credentials are not verified; no prefilled values.
 - [x] Analytics fails closed; stored grant and denial both honoured.
 - [x] Contract tests added and passing (5 tests).
-- [ ] Proof artefacts captured.
-- [ ] Telemetry refreshed.
-- [ ] Slice parked.
+- [x] Proof artefacts captured. (`specs/proofs/web/WEB-036/`, 2026-07-26: contract tests re-run 5/5 against the merged revision.)
+- [x] Telemetry refreshed.
+- [x] Slice parked.
 
 ## Follow-ups (not in this slice)
 - Move `distributor.js` pricing behind an authenticated server route. Until then the gate is

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -208,7 +208,7 @@
           "id": "WEB-036",
           "domain": "web",
           "title": "Distributor portal access gate and consent fail-closed",
-          "status": "active"
+          "status": "done"
         }
       ]
     }

--- a/specs/proofs/web/WEB-036/README.md
+++ b/specs/proofs/web/WEB-036/README.md
@@ -1,0 +1,39 @@
+# WEB-036 Proof - Distributor portal access gate and consent fail-closed
+
+## Scope
+
+The implementation merged to `main` on 2026-07-25 via pull request #1
+(`fix/distributor-access-and-consent-default`, commit `a41bd8c`). This bundle
+records the proof evidence that was still outstanding when the slice code
+landed.
+
+## Contract evidence
+
+- `contract-tests-2026-07-26.txt` - `npx playwright test tests/distributor-access.spec.ts`
+  run locally against the merged code on 2026-07-26: **5 passed, 0 failed**.
+  1. Every portal path redirects to sign in without a session.
+  2. Dealer cost prices and margins stay hidden until sign in.
+  3. The sign-in screen states that credentials are not verified.
+  4. Signing in opens the portal and signing out closes it again.
+  5. A reload drops the session rather than leaving the portal open.
+
+## Consent fail-closed
+
+`analytics.ts` initialises `consentGranted = false`, and `consent.ts` applies
+the stored decision on client load and on the cross-tab `storage` event, so a
+stored denial is honoured on every subsequent visit. This behaviour landed with
+the merged commit; the five contract tests above exercise the portal gate,
+and the consent path is asserted by the existing dealer-locator consent
+payload coverage in the regression suite.
+
+## Honest limits
+
+- The gate is presentation-level only: `distributor.js` pricing is still
+  compiled into the public client bundle. Moving it behind an authenticated
+  server route is recorded as a follow-up in the plan and remains open.
+- Production verification is pending: no deployment has been authorised since
+  the merge, so this proof covers local evidence against the merged revision
+  only. The production check belongs to the deployment slice once the user
+  approves a deploy.
+
+final result: passed (local contract evidence; production pending deployment approval)

--- a/specs/proofs/web/WEB-036/contract-tests-2026-07-26.txt
+++ b/specs/proofs/web/WEB-036/contract-tests-2026-07-26.txt
@@ -1,0 +1,33 @@
+[2m[WebServer] [22m
+[2m[WebServer] [22m> web@0.1.0 dev
+[2m[WebServer] [22m> next dev --webpack --hostname 127.0.0.1 --port 3100
+[2m[WebServer] [22m
+[2m[WebServer] [22m[1m[38;2;173;127;168m▲ Next.js 16.2.10[39m[22m (webpack)
+[2m[WebServer] [22m- Local:         http://127.0.0.1:3100
+[2m[WebServer] [22m- Network:       http://127.0.0.1:3100
+[2m[WebServer] [22m[32m[1m✓[22m[39m Ready in 8.1s
+[2m[WebServer] [22m
+[2m[WebServer] [22m[37m[1m○[22m[39m Compiling / ...
+[2m[WebServer] [22m GET / [32m200[39m in 8.0s[2m (next.js: 7.8s, application-code: 182ms)[22m
+
+Running 5 tests using 1 worker
+
+[2m[WebServer] [22m GET /distributor [32m200[39m in 1337ms[2m (next.js: 1237ms, application-code: 100ms)[22m
+[2m[WebServer] [22m GET /distributor/price-list [32m200[39m in 44ms[2m (next.js: 12ms, application-code: 32ms)[22m
+[2m[WebServer] [22m GET /distributor/order-builder [32m200[39m in 39ms[2m (next.js: 10ms, application-code: 29ms)[22m
+[2m[WebServer] [22m GET /distributor/orders [32m200[39m in 34ms[2m (next.js: 9ms, application-code: 26ms)[22m
+[2m[WebServer] [22m GET /distributor/invoices [32m200[39m in 42ms[2m (next.js: 11ms, application-code: 31ms)[22m
+[2m[WebServer] [22m GET /distributor/account [32m200[39m in 33ms[2m (next.js: 9ms, application-code: 25ms)[22m
+[2m[WebServer] [22m GET /distributor/support [32m200[39m in 48ms[2m (next.js: 9ms, application-code: 39ms)[22m
+  ok 1 [chromium] › tests\distributor-access.spec.ts:32:7 › distributor portal access › every portal path redirects to sign in without a session (10.8s)
+[2m[WebServer] [22m GET /distributor/price-list [32m200[39m in 37ms[2m (next.js: 9ms, application-code: 28ms)[22m
+  ok 2 [chromium] › tests\distributor-access.spec.ts:41:7 › distributor portal access › dealer cost prices and margins stay hidden until sign in (1.2s)
+[2m[WebServer] [22m GET /distributor/sign-in [32m200[39m in 39ms[2m (next.js: 9ms, application-code: 29ms)[22m
+  ok 3 [chromium] › tests\distributor-access.spec.ts:50:7 › distributor portal access › the sign-in screen states that credentials are not verified (1.6s)
+[2m[WebServer] [22m GET /distributor/sign-in [32m200[39m in 36ms[2m (next.js: 8ms, application-code: 28ms)[22m
+  ok 4 [chromium] › tests\distributor-access.spec.ts:59:7 › distributor portal access › signing in opens the portal and signing out closes it again (1.9s)
+[2m[WebServer] [22m GET /distributor/sign-in [32m200[39m in 37ms[2m (next.js: 9ms, application-code: 29ms)[22m
+[2m[WebServer] [22m GET /distributor [32m200[39m in 50ms[2m (next.js: 11ms, application-code: 39ms)[22m
+  ok 5 [chromium] › tests\distributor-access.spec.ts:75:7 › distributor portal access › a reload drops the session rather than leaving the portal open (2.3s)
+
+  5 passed (54.8s)


### PR DESCRIPTION
## Summary

Closes the three outstanding WEB-036 checklist items left open when the implementation merged in PR #1:

- **Proof artefacts captured** — `specs/proofs/web/WEB-036/` with the five distributor access contract tests re-run 5/5 against the merged revision (2026-07-26 log included).
- **Telemetry refreshed** — slice index and progress summary regenerated.
- **Slice parked** — ledger flips WEB-036 to done; local active-slice state returned to IDLE.

The proof records honest limits explicitly: the gate is presentation-level (client-bundle pricing follow-up stays open), and production verification remains pending until a deploy is authorised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)