### PR TITLE
ci(repo): REPO-003 lint only branch-new commits when the reported base is unusable

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -31,10 +31,14 @@ jobs:
         run: |
           BASE="$BASE_SHA"
           # A new branch reports an all-zero "before" sha rather than an empty
-          # one. Falling back to the root commit linted the entire history, and
-          # the legacy commits that predate the convention turned every first
-          # push of a branch red. Lint only what is new to the branch instead.
-          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+          # one, and a force-push can report a "before" that no ref reaches any
+          # more, so the checkout never fetched it. Falling back to the root
+          # commit linted the entire history, and the legacy commits that
+          # predate the convention turned every first push of a branch red.
+          # Whenever the reported base is unusable, lint what is new to the
+          # branch relative to main instead.
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
             git fetch --no-tags origin main
             BASE=$(git merge-base HEAD origin/main)
           fi

--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -30,9 +30,13 @@ jobs:
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           BASE="$BASE_SHA"
-          # A new branch reports an all-zero "before" sha rather than an empty one.
+          # A new branch reports an all-zero "before" sha rather than an empty
+          # one. Falling back to the root commit linted the entire history, and
+          # the legacy commits that predate the convention turned every first
+          # push of a branch red. Lint only what is new to the branch instead.
           if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            BASE=$(git rev-list --max-parents=0 HEAD | head -n 1)
+            git fetch --no-tags origin main
+            BASE=$(git merge-base HEAD origin/main)
           fi
           node tools/spec/verify-commit-range.mjs --base "$BASE" --head "$HEAD_SHA"
       - name: Lint

--- a/specs/notes/plans/repo/REPO-003.md
+++ b/specs/notes/plans/repo/REPO-003.md
@@ -68,9 +68,10 @@
 - [x] First-push fallback lints only branch-new commits — local repro: old root-commit base
       exits 5 with the identical 30-commit failing set CI reported; merge-base base exits 0
       (`specs/proofs/repo/REPO-003/artefacts/`).
-- [ ] Workflow verified green on the first push of a new branch (exercises the merge-base
-      fallback in a real all-zero `before` run).
-- [ ] Telemetry refreshed.
+- [x] Workflow verified green on the first push of a new branch (run 30176201286: real
+      all-zero `before`, merge-base fallback linted only the branch-new commit, all steps
+      green).
+- [x] Telemetry refreshed.
 - [ ] Slice parked.
 
 ## Progress Log
@@ -83,6 +84,10 @@
   Repro note: the local clone was shallow (25 graft points), which initially hid the legacy
   history and made the old fallback look green locally; unshallowed with
   `git fetch --unshallow` so local linting runs on the graph CI sees.
+- 2026-07-26 — Run 30176201286, the first push of `fix/ci-first-push-commit-lint` (real
+  all-zero `before`), green end to end: merge-base fallback fetched `origin/main` and
+  linted exactly the one branch-new commit (`run-first-push-pass.txt`). Remaining for
+  close-out: decide the ledger done-flip and the deploy-web protection question (Risks).
 
 ## Artefact References
 - Guard behaviour: `tools/spec/verify-active-slice.mjs`.

--- a/specs/notes/plans/repo/REPO-003.md
+++ b/specs/notes/plans/repo/REPO-003.md
@@ -58,19 +58,33 @@
    `origin/main` and uses `git merge-base HEAD origin/main`, so a first push lints exactly
    the commits new to the branch — the same range the pull-request path checks. Legacy
    history stays exempt, which is deliberate: those commits are immutable without a rewrite.
+   Hardened after a first-principles sweep of the base cases: a force-push can report a
+   `before` that no ref reaches any more, so the checkout never fetched it and the verifier
+   crashed on the missing object instead of returning a verdict. The condition now treats
+   empty, all-zero, and locally-absent bases alike and routes them all to the merge-base
+   fallback. Remaining sub-case, deliberate: a branch sharing no history with main fails
+   loudly at `git merge-base` — no meaningful lint base exists, and loud is the correct
+   signal.
 
 ## Execution Checklist
 - [x] Guard passes on a clean checkout; still fails locally when working memory is absent.
 - [x] `tsc --noEmit` clean (was 5 errors in `contract.spec.ts`).
 - [x] `npm run lint -w web` — 0 errors, 37 warnings.
 - [x] `npm run test:unit -w web` — 24/24.
-- [x] Workflow verified green on a pull request (runs 30175389163, 30175500903, 2026-07-25).
+- [x] Workflow verified green on a pull request (runs 30175389163, 30175500903, 2026-07-25
+      — pre-fix twins; the lint's pull_request path lints `base.sha..head.sha` and is
+      untouched by steps 5/7). A PR-event run containing this branch awaits PR creation.
 - [x] First-push fallback lints only branch-new commits — local repro: old root-commit base
       exits 5 with the identical 30-commit failing set CI reported; merge-base base exits 0
       (`specs/proofs/repo/REPO-003/artefacts/`).
 - [x] Workflow verified green on the first push of a new branch (run 30176201286: real
       all-zero `before`, merge-base fallback linted only the branch-new commit, all steps
       green).
+- [x] Unusable-base classes all routed to the fallback — crash repro on an unreachable
+      `before` (old code: exit 1, an infrastructure crash rather than a lint verdict) and
+      per-class condition routing (empty/zeros/unreachable → fallback, reachable → reported
+      base) in `unreachable-base-crash.txt` / `hardened-condition-routing.txt`.
+- [ ] Hardened step revalidated live (normal-path push run; captured post-push).
 - [x] Telemetry refreshed.
 - [ ] Slice parked.
 
@@ -88,6 +102,11 @@
   all-zero `before`), green end to end: merge-base fallback fetched `origin/main` and
   linted exactly the one branch-new commit (`run-first-push-pass.txt`). Remaining for
   close-out: decide the ledger done-flip and the deploy-web protection question (Risks).
+- 2026-07-26 — First-principles sweep of the lint base cases (no-corners pass): verified
+  run 30176414181 took the normal path (`BASE_SHA=b87f5aa`, linted exactly `a14b873`);
+  found and closed the unreachable-`before` (force-push) crash by widening the fallback
+  condition to any unusable base; recorded execution-discipline adherence in the proof
+  README and the residual orphan-branch behaviour in step 7.
 
 ## Artefact References
 - Guard behaviour: `tools/spec/verify-active-slice.mjs`.

--- a/specs/notes/plans/repo/REPO-003.md
+++ b/specs/notes/plans/repo/REPO-003.md
@@ -114,6 +114,11 @@
   (`run-normal-push-pass.txt`). The capture commit's own push run repeats that same
   normal path; it is verified before parking but deliberately not re-captured — that is
   where the capture-run regress terminates.
+- 2026-07-26 — Close-out: PR #5 opened for the branch; its pull_request-event guard run
+  30194495011 is green end to end (`run-30194495011-pr-event-pass.txt`), satisfying the
+  awaited PR-event verification of the untouched `base.sha..head.sha` lint path. Ledger
+  done-flip follows in its own commit per the done-phase guard rule; deployment policy
+  stays unchanged per Risks.
 
 ## Artefact References
 - Guard behaviour: `tools/spec/verify-active-slice.mjs`.

--- a/specs/notes/plans/repo/REPO-003.md
+++ b/specs/notes/plans/repo/REPO-003.md
@@ -84,7 +84,9 @@
       `before` (old code: exit 1, an infrastructure crash rather than a lint verdict) and
       per-class condition routing (empty/zeros/unreachable → fallback, reachable → reported
       base) in `unreachable-base-crash.txt` / `hardened-condition-routing.txt`.
-- [ ] Hardened step revalidated live (normal-path push run; captured post-push).
+- [x] Hardened step revalidated live — run 30177048496 (push of 925964f): reachable
+      `before` used as reported, no fallback taken, only the pushed commit linted, all
+      steps green (`run-normal-push-pass.txt`).
 - [x] Telemetry refreshed.
 - [ ] Slice parked.
 
@@ -107,6 +109,11 @@
   found and closed the unreachable-`before` (force-push) crash by widening the fallback
   condition to any unusable base; recorded execution-discipline adherence in the proof
   README and the residual orphan-branch behaviour in step 7.
+- 2026-07-26 — Run 30177048496 (hardened step's own push, reachable `before`): fallback
+  correctly skipped, only the pushed commit linted, workflow green
+  (`run-normal-push-pass.txt`). The capture commit's own push run repeats that same
+  normal path; it is verified before parking but deliberately not re-captured — that is
+  where the capture-run regress terminates.
 
 ## Artefact References
 - Guard behaviour: `tools/spec/verify-active-slice.mjs`.

--- a/specs/notes/plans/repo/REPO-003.md
+++ b/specs/notes/plans/repo/REPO-003.md
@@ -48,17 +48,45 @@
    Verified by removing both `.next` and `next-env.d.ts` locally: the build regenerates the
    file against the build-mode path and the typecheck then passes. This is also the only
    point at which CI verifies the production build.
+7. Base the first-push fallback on the merge-base with `origin/main`, not the root commit.
+   Step 5 made the all-zero `before` sha take the fallback path, but the fallback linted
+   from the repository root — the entire history, 80 non-merge commits — and 30 legacy
+   commits predate the conventional-commit + slice-ID convention. Net effect: the first
+   push of every new branch was red (runs 30175379989 and 30175493102, 2026-07-25 UTC,
+   both failing only "Commit message lint"), while their `pull_request` twins (30175389163,
+   30175500903) passed because that path lints `base.sha..head.sha`. The step now fetches
+   `origin/main` and uses `git merge-base HEAD origin/main`, so a first push lints exactly
+   the commits new to the branch — the same range the pull-request path checks. Legacy
+   history stays exempt, which is deliberate: those commits are immutable without a rewrite.
 
 ## Execution Checklist
 - [x] Guard passes on a clean checkout; still fails locally when working memory is absent.
 - [x] `tsc --noEmit` clean (was 5 errors in `contract.spec.ts`).
 - [x] `npm run lint -w web` — 0 errors, 37 warnings.
 - [x] `npm run test:unit -w web` — 24/24.
-- [ ] Workflow verified green on a pull request.
+- [x] Workflow verified green on a pull request (runs 30175389163, 30175500903, 2026-07-25).
+- [x] First-push fallback lints only branch-new commits — local repro: old root-commit base
+      exits 5 with the identical 30-commit failing set CI reported; merge-base base exits 0
+      (`specs/proofs/repo/REPO-003/artefacts/`).
+- [ ] Workflow verified green on the first push of a new branch (exercises the merge-base
+      fallback in a real all-zero `before` run).
 - [ ] Telemetry refreshed.
 - [ ] Slice parked.
+
+## Progress Log
+- 2026-07-25 — Guard un-blocked (steps 1–6) merged to `main` via PR #2; first real CI signal.
+- 2026-07-26 — First pushes of `feat/web-035-product-true-configurator` and
+  `chore/web-036-proof-close` went red on "Commit message lint" only (runs 30175379989,
+  30175493102). Diagnosed the root-commit fallback as the cause; PR twins green at the same
+  SHAs. Implemented step 7 on `fix/ci-first-push-commit-lint`; captured failing-run logs,
+  local old-vs-new repro (failing sets identical to CI, 30/30), and refreshed telemetry.
+  Repro note: the local clone was shallow (25 graft points), which initially hid the legacy
+  history and made the old fallback look green locally; unshallowed with
+  `git fetch --unshallow` so local linting runs on the graph CI sees.
 
 ## Artefact References
 - Guard behaviour: `tools/spec/verify-active-slice.mjs`.
 - Workflow: `.github/workflows/guard.yml`.
+- First-push lint proof bundle: `specs/proofs/repo/REPO-003/` (failed-run logs, old/new
+  fallback repro, failing-set comparison, telemetry logs).
 - Deployment risk note: see Risks above; unchanged in this slice by design.

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -30,7 +30,7 @@
           "id": "REPO-003",
           "domain": "repo",
           "title": "Unblock the guard workflow and restore CI checks",
-          "status": "active"
+          "status": "done"
         }
       ]
     },

--- a/specs/proofs/repo/REPO-003/README.md
+++ b/specs/proofs/repo/REPO-003/README.md
@@ -51,9 +51,9 @@ signal.
   hardened condition evaluated per base class (empty/zeros/unreachable route to
   the fallback, a reachable base is used as reported) plus an end-to-end
   fallback run exiting 0.
-- `artefacts/run-normal-push-pass.txt` — normal-path push run of the hardened
-  step: a non-zero, reachable `before` used as reported, linting only the newly
-  pushed commits. (Added after the push; see RESULT.)
+- `artefacts/run-normal-push-pass.txt` — run 30177048496, the push of the
+  hardened step itself: a non-zero, reachable `before` used as reported (no
+  fetch, no fallback), linting only the newly pushed commit; workflow green.
 - `artefacts/run-first-push-pass.txt` — run 30176201286, the first push of
   `fix/ci-first-push-commit-lint`: a real all-zero `before` event. The step log
   shows `BASE_SHA` all zeros, the fetch of `origin/main`, and the merge-base
@@ -101,5 +101,8 @@ RESULT: PASS (local repro + failing-run evidence; failing sets identical to CI).
 RESULT: PASS (CI) — run 30176201286, the first push of the fix branch (all-zero
 `before`), completed success with the merge-base fallback linting only the
 branch-new commit.
-RESULT: hardening revalidation PENDING — normal-path run after this push;
-updated on completion.
+RESULT: PASS (CI) — run 30177048496, the hardened step's own push (reachable
+`before`, normal path): fallback correctly skipped, only the pushed commit
+linted, workflow green. The capture commit after it revalidates the same
+normal path once more; its run is cited in the plan progress log rather than
+re-captured here, which is where the capture-run regress terminates.

--- a/specs/proofs/repo/REPO-003/README.md
+++ b/specs/proofs/repo/REPO-003/README.md
@@ -42,9 +42,10 @@ without a rewrite.
 - `artefacts/failing-set-comparison.txt` — failing-SHA sets extracted from the CI
   logs vs the local repro: IDENTICAL for both runs (30/30), proving the repro
   exercises the same range CI did.
-- `artefacts/run-first-push-pass.txt` — guard run on the first push of
-  `fix/ci-first-push-commit-lint`, a real all-zero `before` event exercising the
-  new merge-base path end to end. (Added after the push; see RESULT.)
+- `artefacts/run-first-push-pass.txt` — run 30176201286, the first push of
+  `fix/ci-first-push-commit-lint`: a real all-zero `before` event. The step log
+  shows `BASE_SHA` all zeros, the fetch of `origin/main`, and the merge-base
+  path linting exactly the one branch-new commit; the whole workflow is green.
 
 Repro environment note: the local clone was shallow (25 graft points in
 `.git/shallow`), which hid the legacy history and initially made the old fallback
@@ -63,4 +64,6 @@ linted ranges.
 - `artefacts/progress.txt`
 
 RESULT: PASS (local repro + failing-run evidence; failing sets identical to CI).
-RESULT: CI first-push verification PENDING — updated after the fix branch is pushed.
+RESULT: PASS (CI) — run 30176201286, the first push of the fix branch (all-zero
+`before`), completed success with the merge-base fallback linting only the
+branch-new commit.

--- a/specs/proofs/repo/REPO-003/README.md
+++ b/specs/proofs/repo/REPO-003/README.md
@@ -1,0 +1,66 @@
+# Proof — REPO-003 (Unblock the guard workflow and restore CI checks)
+
+This bundle covers the first-push commit-lint fallback fix in
+`.github/workflows/guard.yml` (plan step 7).
+
+## Defect
+
+A push that creates a new branch reports an all-zero `before` sha. The workflow's
+fallback linted from the repository root commit — the entire history, 80 non-merge
+commits — and 30 legacy commits predate the conventional-commit + slice-ID
+convention, so the first push of every new branch failed "Commit message lint"
+(exit 5) while every later push and every `pull_request` run passed.
+
+Observed failures (both 2026-07-25 UTC, failing only "Commit message lint"):
+
+- Run 30175379989 — push of `feat/web-035-product-true-configurator`
+  (head `990544b`). PR twin 30175389163 at the same sha: success.
+- Run 30175493102 — push of `chore/web-036-proof-close`
+  (head `847187f`). PR twin 30175500903 at the same sha: success.
+
+## Fix
+
+When `BASE` is empty or all zeros, fetch `origin/main` and use
+`git merge-base HEAD origin/main` as the lint base, so a first push lints exactly
+the commits new to the branch — the same range the `pull_request` path checks
+(`base.sha..head.sha`). Legacy history stays exempt by design; it is immutable
+without a rewrite.
+
+## Verification
+
+- `artefacts/run-30175379989-commit-lint-failure.txt`,
+  `artefacts/run-30175493102-commit-lint-failure.txt` — CI logs of both failed
+  runs (`gh run view --log-failed`): all-zero `BASE_SHA` in the step env, 30
+  nonconforming commits, exit 5.
+- `artefacts/old-fallback-web035-root-base.txt`,
+  `artefacts/old-fallback-web036-root-base.txt` — local repro of the old
+  fallback (`git rev-list --max-parents=0 | head -n 1` as base) against the exact
+  pushed HEADs: exit 5, 30 failures, 80 commits linted.
+- `artefacts/new-fallback-web035-merge-base.txt`,
+  `artefacts/new-fallback-web036-merge-base.txt` — same HEADs with the
+  merge-base fallback: exit 0, exactly the branch-new commits linted (2 each).
+- `artefacts/failing-set-comparison.txt` — failing-SHA sets extracted from the CI
+  logs vs the local repro: IDENTICAL for both runs (30/30), proving the repro
+  exercises the same range CI did.
+- `artefacts/run-first-push-pass.txt` — guard run on the first push of
+  `fix/ci-first-push-commit-lint`, a real all-zero `before` event exercising the
+  new merge-base path end to end. (Added after the push; see RESULT.)
+
+Repro environment note: the local clone was shallow (25 graft points in
+`.git/shallow`), which hid the legacy history and initially made the old fallback
+look green locally. The clone was unshallowed with `git fetch --unshallow` before
+the repro so local ranges match the graph CI sees with `fetch-depth: 0`.
+
+Parity/production note: this slice changes GitHub Actions configuration only — no
+application behaviour, so the docker parity stack does not apply. The paired
+evidence for a workflow file is the failing production runs (above) and the
+passing production run after the fix, plus the deterministic local repro of the
+linted ranges.
+
+## Telemetry
+
+- `artefacts/slice-index.txt`
+- `artefacts/progress.txt`
+
+RESULT: PASS (local repro + failing-run evidence; failing sets identical to CI).
+RESULT: CI first-push verification PENDING — updated after the fix branch is pushed.

--- a/specs/proofs/repo/REPO-003/README.md
+++ b/specs/proofs/repo/REPO-003/README.md
@@ -20,11 +20,14 @@ Observed failures (both 2026-07-25 UTC, failing only "Commit message lint"):
 
 ## Fix
 
-When `BASE` is empty or all zeros, fetch `origin/main` and use
-`git merge-base HEAD origin/main` as the lint base, so a first push lints exactly
+When `BASE` is unusable — empty, all zeros (branch creation), or not present
+locally (a force-push rewrote it away) — fetch `origin/main` and use
+`git merge-base HEAD origin/main` as the lint base, so the push lints exactly
 the commits new to the branch — the same range the `pull_request` path checks
 (`base.sha..head.sha`). Legacy history stays exempt by design; it is immutable
-without a rewrite.
+without a rewrite. A branch sharing no history with main fails loudly at
+`git merge-base`: no meaningful base exists there, and loud is the correct
+signal.
 
 ## Verification
 
@@ -42,6 +45,15 @@ without a rewrite.
 - `artefacts/failing-set-comparison.txt` — failing-SHA sets extracted from the CI
   logs vs the local repro: IDENTICAL for both runs (30/30), proving the repro
   exercises the same range CI did.
+- `artefacts/unreachable-base-crash.txt` — pre-hardening: a `before` that no
+  ref reaches (any history-rewriting force-push) crashed the verifier — exit 1,
+  no lint verdict at all. `artefacts/hardened-condition-routing.txt` — the
+  hardened condition evaluated per base class (empty/zeros/unreachable route to
+  the fallback, a reachable base is used as reported) plus an end-to-end
+  fallback run exiting 0.
+- `artefacts/run-normal-push-pass.txt` — normal-path push run of the hardened
+  step: a non-zero, reachable `before` used as reported, linting only the newly
+  pushed commits. (Added after the push; see RESULT.)
 - `artefacts/run-first-push-pass.txt` — run 30176201286, the first push of
   `fix/ci-first-push-commit-lint`: a real all-zero `before` event. The step log
   shows `BASE_SHA` all zeros, the fetch of `origin/main`, and the merge-base
@@ -58,6 +70,28 @@ evidence for a workflow file is the failing production runs (above) and the
 passing production run after the fix, plus the deterministic local repro of the
 linted ranges.
 
+## Execution-discipline adherence (AGENTS.md)
+
+1. Governance refresh — `spec:slice-index` + `spec:progress` run after each
+   deliverable; logs in `artefacts/slice-index.txt`, `artefacts/progress.txt`;
+   no drift errors at any commit.
+2. Lint/test sweep — no application code touched; the authoritative sweep for a
+   workflow change is the workflow itself: the full guard suite (lint, build,
+   typecheck, unit, Playwright contract, reference validation) ran green on
+   every push of this branch (runs 30176201286, 30176414181, and the
+   post-hardening run in RESULT). The changed lint logic is covered by the
+   deterministic node/bash repros in this bundle.
+3. Slice lifecycle — REPO-003 active for every edit and commit; parked to IDLE
+   only with a clean tree and pushes recorded.
+4. Artefact curation — every file under `artefacts/` is referenced in this
+   README exactly once; no unreferenced captures.
+5. Parallel guard prep — hooks only re-verify (scope guard, commit-msg) and add
+   no new work at commit time.
+6. Session runtime ledger — no dev servers or parity stack required
+   (CI-configuration slice; rationale in the parity note above);
+   `dev-processes.json` stayed empty.
+7. Privileged command queueing — no privileged commands used.
+
 ## Telemetry
 
 - `artefacts/slice-index.txt`
@@ -67,3 +101,5 @@ RESULT: PASS (local repro + failing-run evidence; failing sets identical to CI).
 RESULT: PASS (CI) — run 30176201286, the first push of the fix branch (all-zero
 `before`), completed success with the merge-base fallback linting only the
 branch-new commit.
+RESULT: hardening revalidation PENDING — normal-path run after this push;
+updated on completion.

--- a/specs/proofs/repo/REPO-003/artefacts/failing-set-comparison.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/failing-set-comparison.txt
@@ -1,0 +1,42 @@
+# Failing-commit set comparison: CI runs vs local repro of the old root-commit fallback
+# Extraction: lines 'Commit <sha>: <verdict>' where verdict != OK, deduped+sorted.
+
+run 30175493102 (chore/web-036-proof-close): 30 failing SHAs
+local repro (old fallback, same HEAD):        30 failing SHAs
+diff: IDENTICAL
+
+run 30175379989 (feat/web-035-product-true-configurator): 30 failing SHAs
+local repro (old fallback, same HEAD):        30 failing SHAs
+diff: IDENTICAL
+
+# The 30 nonconforming commits (shared by both runs):
+0647d0f925066def91fcb5f77ecac08b475ee7ec
+13c560cf6db050111ad1c402dd58922fba9eb708
+2bd41e9ddfb0c9415fec06e5c65030f8703d2a91
+361c13651ad04ea84b721f311254b280dabf799f
+3c8c7a8a058ca71c62bad008cb4f5eeb66bee922
+410775fb39c516a821d754cfbe07c8f12130d592
+42f411a382d0995624aaea9c67f562e514e09f02
+4617536c728ab0d0211104813b81893a4d51e8d8
+53887c2a5197a4072f8b7abbf189581f805b88f1
+55d3e4daafe50221edf8e9d745f49aa9ceccb7c5
+590d9e821976beabd99fd9b29006f07dbd9a092a
+654702582a299e80175cff4106db501f8dd8c289
+6a11a306ae5598fde6adbff2eb224f08836a0912
+6d252fb305ff34931868777b6622473fa6586150
+6d293a7a26b2452754b0ebbbe7803ec4724daca3
+7651b5388bad88100b387841b0a7f364cba150de
+84f83455737086a66826a419c38da67822b34171
+886110c4773c05418b5a6650d38f49591f5e2cc1
+934821c15ab5bf5ec85baece5cc049165cf6cf93
+937fe7191bcea6b6daf4f02ead1082346ad63488
+948f0ba3d2626b11edafa92cf6da639679d8db68
+9907c433d1fc8fbec50d1e2f6f831635528811df
+a401e6d2d5730b01801d2e9566df2370c1bc6847
+a971b2b173bce786dadee68a787ebb02468800bb
+ae17d7ccbd883c5b85b3dd07a143310c99d60a44
+bcbfea1cee5f2281903f3d90414bc8d75335e7aa
+c852496f55551062cd3e384ac41b7a297f0b9927
+df4972687e5ecf4aaf9bc76510016e3c17e8b958
+e09aa7327c8b44a2ae3d741686e8d0a3ece625d8
+f9fcedd63c7b9e200a17a8a0c2e0839a72c371a2

--- a/specs/proofs/repo/REPO-003/artefacts/hardened-condition-routing.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/hardened-condition-routing.txt
@@ -1,0 +1,12 @@
+# hardened condition routing — the exact guard.yml test evaluated per base class
+empty        -> fallback (merge-base with origin/main)
+zeros        -> fallback (merge-base with origin/main)
+unreachable  -> fallback (merge-base with origin/main)
+reachable    -> use reported before
+
+# end-to-end with an unreachable base: fallback resolves and the range lints clean
+merge-base HEAD origin/main = b790a0956e868493f3288f9106382614e55480ab
+Commit a14b873c536398331a7651a04ae42be0a09dd180: OK
+Commit b87f5aa56deb059e89ebb480920e0feda4f68dfe: OK
+All commit messages look good
+# exit=0

--- a/specs/proofs/repo/REPO-003/artefacts/new-fallback-web035-merge-base.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/new-fallback-web035-merge-base.txt
@@ -1,0 +1,6 @@
+# repro (full history, post-unshallow): NEW fallback BASE=$(git merge-base HEAD origin/main)
+# branch feat/web-035-product-true-configurator — BASE=b790a0956e868493f3288f9106382614e55480ab  HEAD=990544b5c457a14bf9fe800b8ee94c7c073388f3
+Commit 990544b5c457a14bf9fe800b8ee94c7c073388f3: OK
+Commit b45257e4d6418c6c246cbffd86a4459020d571c8: OK
+All commit messages look good
+# exit=0

--- a/specs/proofs/repo/REPO-003/artefacts/new-fallback-web036-merge-base.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/new-fallback-web036-merge-base.txt
@@ -1,0 +1,6 @@
+# repro (full history, post-unshallow): NEW fallback BASE=$(git merge-base HEAD origin/main)
+# branch chore/web-036-proof-close — BASE=b790a0956e868493f3288f9106382614e55480ab  HEAD=847187f1b4b421832dea4ed23d5e220ce7133f2a
+Commit 847187f1b4b421832dea4ed23d5e220ce7133f2a: OK
+Commit 674293634979f409dcc74171cc55924eaea5a1f0: OK
+All commit messages look good
+# exit=0

--- a/specs/proofs/repo/REPO-003/artefacts/old-fallback-web035-root-base.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/old-fallback-web035-root-base.txt
@@ -1,0 +1,84 @@
+# repro (full history, post-unshallow): OLD fallback BASE=$(git rev-list --max-parents=0 HEAD | head -n 1)
+# branch feat/web-035-product-true-configurator — BASE=16974a0db674a12830651b022a876da766edeb9c  HEAD=990544b5c457a14bf9fe800b8ee94c7c073388f3
+Commit 990544b5c457a14bf9fe800b8ee94c7c073388f3: OK
+Commit b45257e4d6418c6c246cbffd86a4459020d571c8: OK
+Commit a41bd8cd115ea38bed9424d09050a43f62a86c14: OK
+Commit 888c61219dfcb7b4c4e5942e93f5cab9749e2ea0: OK
+Commit 6698fca9768192baf4f757e466142fcba326a64e: OK
+Commit b03dd9b310bd68f5f73731441380fdb9e732939b: OK
+Commit abbd1629fe4da3166378e93218a1dcdc704c6a4e: OK
+Commit a401e6d2d5730b01801d2e9566df2370c1bc6847: No slice ID pattern (e.g., ABC-123) found in commit message
+Commit 590d9e821976beabd99fd9b29006f07dbd9a092a: No slice ID pattern (e.g., ABC-123) found in commit message
+Commit 6d252fb305ff34931868777b6622473fa6586150: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 0647d0f925066def91fcb5f77ecac08b475ee7ec: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 84f83455737086a66826a419c38da67822b34171: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 53887c2a5197a4072f8b7abbf189581f805b88f1: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 937fe7191bcea6b6daf4f02ead1082346ad63488: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit c852496f55551062cd3e384ac41b7a297f0b9927: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 886110c4773c05418b5a6650d38f49591f5e2cc1: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit a971b2b173bce786dadee68a787ebb02468800bb: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit bcbfea1cee5f2281903f3d90414bc8d75335e7aa: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 13c560cf6db050111ad1c402dd58922fba9eb708: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 948f0ba3d2626b11edafa92cf6da639679d8db68: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 361c13651ad04ea84b721f311254b280dabf799f: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 654702582a299e80175cff4106db501f8dd8c289: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit f9fcedd63c7b9e200a17a8a0c2e0839a72c371a2: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 6a11a306ae5598fde6adbff2eb224f08836a0912: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit df4972687e5ecf4aaf9bc76510016e3c17e8b958: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 55d3e4daafe50221edf8e9d745f49aa9ceccb7c5: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 4617536c728ab0d0211104813b81893a4d51e8d8: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 2bd41e9ddfb0c9415fec06e5c65030f8703d2a91: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 9907c433d1fc8fbec50d1e2f6f831635528811df: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit e09aa7327c8b44a2ae3d741686e8d0a3ece625d8: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 3c8c7a8a058ca71c62bad008cb4f5eeb66bee922: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 410775fb39c516a821d754cfbe07c8f12130d592: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 42f411a382d0995624aaea9c67f562e514e09f02: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 7651b5388bad88100b387841b0a7f364cba150de: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 934821c15ab5bf5ec85baece5cc049165cf6cf93: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit ae17d7ccbd883c5b85b3dd07a143310c99d60a44: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 6d293a7a26b2452754b0ebbbe7803ec4724daca3: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit e9829b47d3e4e59b004e2a2099e26dce4bfd4f16: OK
+Commit fc3abf8595da352000d923af11e56bf3e8e99e74: OK
+Commit ccaea649388dfbc8f65e930151f572fc49aa2146: OK
+Commit 5c305831a1c6187f4559399d8d4c825e83d09d18: OK
+Commit 23dacfb7bf9d93c2916e46af52a40f250fe6a9d8: OK
+Commit f019672618958f29090ed632581c358489a74c0d: OK
+Commit 2fcb1bb1f849cbcb8493bd81a41cac1d7476a5fd: OK
+Commit f966bc8dc70064c70dea0a2f3ed5c330d6711229: OK
+Commit 52de3e8120ae4a47c1584ea3370fe9cb41640cd9: OK
+Commit 6f51669ee15fcdb6d4fdcef0d87f93c87899bc0b: OK
+Commit 6316e52c8c201cb7d48b6fef12847fa94cb541f1: OK
+Commit 625d5b0fcf31d366f5eb5665257f7d55ceb13eb3: OK
+Commit 6dacc9e8d376fe195d48bd598160704190242d39: OK
+Commit b804d915c03f2857dd74bb1ee4fa72f4617dfa98: OK
+Commit e125fb58f5c30d5e93f653dfcbec02683f84f3ad: OK
+Commit d70145711ca49c26d115bfdb60dc904201bab2e5: OK
+Commit 44d943aa51b1adb7c99fbf39d30f8a8991324417: OK
+Commit c23b29ad648445c31dafc94012604ce2d34b7cff: OK
+Commit 01d4c73c1bc5c65ec3ee9b0076e4b7b0d6317c59: OK
+Commit 3de632165cb514f9549b7d0740e03e9c08409d03: OK
+Commit e679c34f8d412c4190a2fa3d964479ef246bd2da: OK
+Commit 9906907477561c9a030c5f31707407cecb77f23a: OK
+Commit 8e8cb8207ce26565c0777b8b5cb8efabe54a1329: OK
+Commit b14c48c56d3dbf2bbbd2989de362747921aa8668: OK
+Commit 73e29dbe231f1649db99874c50df904f182000fd: OK
+Commit fdcd193ce17a3e3548f429903b7fef181a508605: OK
+Commit 66243b56b5bfc9c7e99d2bf7ebf6cfe86994d494: OK
+Commit ca34ffed190a097079bb9e45c8cc0d17e63d1037: OK
+Commit 12913ea7a095a6f6ff6ea07f635356e7116bb2dd: OK
+Commit c1a974d0fcca74147c416fcc261070f7650bb831: OK
+Commit 73c241a34e30a11f8830e78e2899a780c0aa5dff: OK
+Commit f005f4c872490fcd1ada35ed2d5bd2fc091d491c: OK
+Commit 62682fa918c01068e158af1504987c04ddc7506b: OK
+Commit 50c19d082e69d66f37f3ef044808be0a431133c5: OK
+Commit 8e88ee2d9d79a85966ae001d9ce5731ba63d7d04: OK
+Commit 6e12a05a7317f6667542748c938b443cbb1496e0: OK
+Commit 0334c1126c6e1e1d26b986c450e0fc296e322eb6: OK
+Commit 9189cc2e630c05b60ea09588b9df71367616ee42: OK
+Commit d40056a971abf1751184ee0648b916cffe378eca: OK
+Commit cc0f1e153397038fdd2afc939b18a9eb47531fef: OK
+Commit 2180adb42a4bdd1acf56f9aa84d2be78aeb048bc: OK
+Commit 3bf3650c3c0428148215fd854c44a412511c5a1f: OK
+Commit e942290fbbe96df00f9a27d677b29ccb546912c4: OK
+Commit message verification failed (30 commits).
+# exit=5

--- a/specs/proofs/repo/REPO-003/artefacts/old-fallback-web036-root-base.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/old-fallback-web036-root-base.txt
@@ -1,0 +1,84 @@
+# repro (full history, post-unshallow): OLD fallback BASE=$(git rev-list --max-parents=0 HEAD | head -n 1)
+# branch chore/web-036-proof-close — BASE=16974a0db674a12830651b022a876da766edeb9c  HEAD=847187f1b4b421832dea4ed23d5e220ce7133f2a
+Commit 847187f1b4b421832dea4ed23d5e220ce7133f2a: OK
+Commit 674293634979f409dcc74171cc55924eaea5a1f0: OK
+Commit a41bd8cd115ea38bed9424d09050a43f62a86c14: OK
+Commit 888c61219dfcb7b4c4e5942e93f5cab9749e2ea0: OK
+Commit 6698fca9768192baf4f757e466142fcba326a64e: OK
+Commit b03dd9b310bd68f5f73731441380fdb9e732939b: OK
+Commit abbd1629fe4da3166378e93218a1dcdc704c6a4e: OK
+Commit a401e6d2d5730b01801d2e9566df2370c1bc6847: No slice ID pattern (e.g., ABC-123) found in commit message
+Commit 590d9e821976beabd99fd9b29006f07dbd9a092a: No slice ID pattern (e.g., ABC-123) found in commit message
+Commit 6d252fb305ff34931868777b6622473fa6586150: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 0647d0f925066def91fcb5f77ecac08b475ee7ec: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 84f83455737086a66826a419c38da67822b34171: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 53887c2a5197a4072f8b7abbf189581f805b88f1: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 937fe7191bcea6b6daf4f02ead1082346ad63488: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit c852496f55551062cd3e384ac41b7a297f0b9927: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 886110c4773c05418b5a6650d38f49591f5e2cc1: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit a971b2b173bce786dadee68a787ebb02468800bb: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit bcbfea1cee5f2281903f3d90414bc8d75335e7aa: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 13c560cf6db050111ad1c402dd58922fba9eb708: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 948f0ba3d2626b11edafa92cf6da639679d8db68: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 361c13651ad04ea84b721f311254b280dabf799f: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 654702582a299e80175cff4106db501f8dd8c289: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit f9fcedd63c7b9e200a17a8a0c2e0839a72c371a2: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 6a11a306ae5598fde6adbff2eb224f08836a0912: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit df4972687e5ecf4aaf9bc76510016e3c17e8b958: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 55d3e4daafe50221edf8e9d745f49aa9ceccb7c5: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 4617536c728ab0d0211104813b81893a4d51e8d8: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 2bd41e9ddfb0c9415fec06e5c65030f8703d2a91: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 9907c433d1fc8fbec50d1e2f6f831635528811df: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit e09aa7327c8b44a2ae3d741686e8d0a3ece625d8: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 3c8c7a8a058ca71c62bad008cb4f5eeb66bee922: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 410775fb39c516a821d754cfbe07c8f12130d592: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 42f411a382d0995624aaea9c67f562e514e09f02: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 7651b5388bad88100b387841b0a7f364cba150de: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 934821c15ab5bf5ec85baece5cc049165cf6cf93: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit ae17d7ccbd883c5b85b3dd07a143310c99d60a44: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit 6d293a7a26b2452754b0ebbbe7803ec4724daca3: Missing conventional commit prefix (e.g., "docs(scope): message")
+Commit e9829b47d3e4e59b004e2a2099e26dce4bfd4f16: OK
+Commit fc3abf8595da352000d923af11e56bf3e8e99e74: OK
+Commit ccaea649388dfbc8f65e930151f572fc49aa2146: OK
+Commit 5c305831a1c6187f4559399d8d4c825e83d09d18: OK
+Commit 23dacfb7bf9d93c2916e46af52a40f250fe6a9d8: OK
+Commit f019672618958f29090ed632581c358489a74c0d: OK
+Commit 2fcb1bb1f849cbcb8493bd81a41cac1d7476a5fd: OK
+Commit f966bc8dc70064c70dea0a2f3ed5c330d6711229: OK
+Commit 52de3e8120ae4a47c1584ea3370fe9cb41640cd9: OK
+Commit 6f51669ee15fcdb6d4fdcef0d87f93c87899bc0b: OK
+Commit 6316e52c8c201cb7d48b6fef12847fa94cb541f1: OK
+Commit 625d5b0fcf31d366f5eb5665257f7d55ceb13eb3: OK
+Commit 6dacc9e8d376fe195d48bd598160704190242d39: OK
+Commit b804d915c03f2857dd74bb1ee4fa72f4617dfa98: OK
+Commit e125fb58f5c30d5e93f653dfcbec02683f84f3ad: OK
+Commit d70145711ca49c26d115bfdb60dc904201bab2e5: OK
+Commit 44d943aa51b1adb7c99fbf39d30f8a8991324417: OK
+Commit c23b29ad648445c31dafc94012604ce2d34b7cff: OK
+Commit 01d4c73c1bc5c65ec3ee9b0076e4b7b0d6317c59: OK
+Commit 3de632165cb514f9549b7d0740e03e9c08409d03: OK
+Commit e679c34f8d412c4190a2fa3d964479ef246bd2da: OK
+Commit 9906907477561c9a030c5f31707407cecb77f23a: OK
+Commit 8e8cb8207ce26565c0777b8b5cb8efabe54a1329: OK
+Commit b14c48c56d3dbf2bbbd2989de362747921aa8668: OK
+Commit 73e29dbe231f1649db99874c50df904f182000fd: OK
+Commit fdcd193ce17a3e3548f429903b7fef181a508605: OK
+Commit 66243b56b5bfc9c7e99d2bf7ebf6cfe86994d494: OK
+Commit ca34ffed190a097079bb9e45c8cc0d17e63d1037: OK
+Commit 12913ea7a095a6f6ff6ea07f635356e7116bb2dd: OK
+Commit c1a974d0fcca74147c416fcc261070f7650bb831: OK
+Commit 73c241a34e30a11f8830e78e2899a780c0aa5dff: OK
+Commit f005f4c872490fcd1ada35ed2d5bd2fc091d491c: OK
+Commit 62682fa918c01068e158af1504987c04ddc7506b: OK
+Commit 50c19d082e69d66f37f3ef044808be0a431133c5: OK
+Commit 8e88ee2d9d79a85966ae001d9ce5731ba63d7d04: OK
+Commit 6e12a05a7317f6667542748c938b443cbb1496e0: OK
+Commit 0334c1126c6e1e1d26b986c450e0fc296e322eb6: OK
+Commit 9189cc2e630c05b60ea09588b9df71367616ee42: OK
+Commit d40056a971abf1751184ee0648b916cffe378eca: OK
+Commit cc0f1e153397038fdd2afc939b18a9eb47531fef: OK
+Commit 2180adb42a4bdd1acf56f9aa84d2be78aeb048bc: OK
+Commit 3bf3650c3c0428148215fd854c44a412511c5a1f: OK
+Commit e942290fbbe96df00f9a27d677b29ccb546912c4: OK
+Commit message verification failed (30 commits).
+# exit=5

--- a/specs/proofs/repo/REPO-003/artefacts/progress.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/progress.txt
@@ -1,0 +1,5 @@
+
+> spec:progress
+> node tools/spec/progress.mjs
+
+Progress summary updated at specs/project-progress/progress-summary.json

--- a/specs/proofs/repo/REPO-003/artefacts/run-30175379989-commit-lint-failure.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/run-30175379989-commit-lint-failure.txt
@@ -1,0 +1,94 @@
+guard	Commit message lint	﻿2026-07-25T21:20:11.2219043Z ##[group]Run BASE="$BASE_SHA"
+guard	Commit message lint	2026-07-25T21:20:11.2219503Z ^[[36;1mBASE="$BASE_SHA"^[[0m
+guard	Commit message lint	2026-07-25T21:20:11.2219866Z ^[[36;1m# A new branch reports an all-zero "before" sha rather than an empty one.^[[0m
+guard	Commit message lint	2026-07-25T21:20:11.2220389Z ^[[36;1mif [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then^[[0m
+guard	Commit message lint	2026-07-25T21:20:11.2220852Z ^[[36;1m  BASE=$(git rev-list --max-parents=0 HEAD | head -n 1)^[[0m
+guard	Commit message lint	2026-07-25T21:20:11.2221183Z ^[[36;1mfi^[[0m
+guard	Commit message lint	2026-07-25T21:20:11.2221519Z ^[[36;1mnode tools/spec/verify-commit-range.mjs --base "$BASE" --head "$HEAD_SHA"^[[0m
+guard	Commit message lint	2026-07-25T21:20:11.2265804Z shell: /usr/bin/bash -e {0}
+guard	Commit message lint	2026-07-25T21:20:11.2266069Z env:
+guard	Commit message lint	2026-07-25T21:20:11.2266286Z   BASE_SHA: 0000000000000000000000000000000000000000
+guard	Commit message lint	2026-07-25T21:20:11.2266622Z   HEAD_SHA: 990544b5c457a14bf9fe800b8ee94c7c073388f3
+guard	Commit message lint	2026-07-25T21:20:11.2266922Z ##[endgroup]
+guard	Commit message lint	2026-07-25T21:20:11.5325848Z Commit 990544b5c457a14bf9fe800b8ee94c7c073388f3: OK
+guard	Commit message lint	2026-07-25T21:20:11.5329558Z Commit b45257e4d6418c6c246cbffd86a4459020d571c8: OK
+guard	Commit message lint	2026-07-25T21:20:11.5330675Z Commit a41bd8cd115ea38bed9424d09050a43f62a86c14: OK
+guard	Commit message lint	2026-07-25T21:20:11.5331683Z Commit 888c61219dfcb7b4c4e5942e93f5cab9749e2ea0: OK
+guard	Commit message lint	2026-07-25T21:20:11.5332896Z Commit 6698fca9768192baf4f757e466142fcba326a64e: OK
+guard	Commit message lint	2026-07-25T21:20:11.5333755Z Commit b03dd9b310bd68f5f73731441380fdb9e732939b: OK
+guard	Commit message lint	2026-07-25T21:20:11.5334605Z Commit abbd1629fe4da3166378e93218a1dcdc704c6a4e: OK
+guard	Commit message lint	2026-07-25T21:20:11.5336229Z Commit a401e6d2d5730b01801d2e9566df2370c1bc6847: No slice ID pattern (e.g., ABC-123) found in commit message
+guard	Commit message lint	2026-07-25T21:20:11.5338360Z Commit 590d9e821976beabd99fd9b29006f07dbd9a092a: No slice ID pattern (e.g., ABC-123) found in commit message
+guard	Commit message lint	2026-07-25T21:20:11.5340153Z Commit 6d252fb305ff34931868777b6622473fa6586150: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5342256Z Commit 0647d0f925066def91fcb5f77ecac08b475ee7ec: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5344121Z Commit 84f83455737086a66826a419c38da67822b34171: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5346097Z Commit 53887c2a5197a4072f8b7abbf189581f805b88f1: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5347612Z Commit 937fe7191bcea6b6daf4f02ead1082346ad63488: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5349453Z Commit c852496f55551062cd3e384ac41b7a297f0b9927: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5351415Z Commit 886110c4773c05418b5a6650d38f49591f5e2cc1: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5353381Z Commit a971b2b173bce786dadee68a787ebb02468800bb: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5355162Z Commit bcbfea1cee5f2281903f3d90414bc8d75335e7aa: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5356630Z Commit 13c560cf6db050111ad1c402dd58922fba9eb708: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5357592Z Commit 948f0ba3d2626b11edafa92cf6da639679d8db68: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5358516Z Commit 361c13651ad04ea84b721f311254b280dabf799f: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5359477Z Commit 654702582a299e80175cff4106db501f8dd8c289: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5360372Z Commit f9fcedd63c7b9e200a17a8a0c2e0839a72c371a2: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5361268Z Commit 6a11a306ae5598fde6adbff2eb224f08836a0912: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5362640Z Commit df4972687e5ecf4aaf9bc76510016e3c17e8b958: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5364437Z Commit 55d3e4daafe50221edf8e9d745f49aa9ceccb7c5: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5367022Z Commit 4617536c728ab0d0211104813b81893a4d51e8d8: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5368840Z Commit 2bd41e9ddfb0c9415fec06e5c65030f8703d2a91: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5370654Z Commit 9907c433d1fc8fbec50d1e2f6f831635528811df: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5372701Z Commit e09aa7327c8b44a2ae3d741686e8d0a3ece625d8: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5374459Z Commit 3c8c7a8a058ca71c62bad008cb4f5eeb66bee922: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5376202Z Commit 410775fb39c516a821d754cfbe07c8f12130d592: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5377976Z Commit 42f411a382d0995624aaea9c67f562e514e09f02: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5379795Z Commit 7651b5388bad88100b387841b0a7f364cba150de: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5381616Z Commit 934821c15ab5bf5ec85baece5cc049165cf6cf93: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5383746Z Commit ae17d7ccbd883c5b85b3dd07a143310c99d60a44: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5385568Z Commit 6d293a7a26b2452754b0ebbbe7803ec4724daca3: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:20:11.5386806Z Commit e9829b47d3e4e59b004e2a2099e26dce4bfd4f16: OK
+guard	Commit message lint	2026-07-25T21:20:11.5387607Z Commit fc3abf8595da352000d923af11e56bf3e8e99e74: OK
+guard	Commit message lint	2026-07-25T21:20:11.5388373Z Commit ccaea649388dfbc8f65e930151f572fc49aa2146: OK
+guard	Commit message lint	2026-07-25T21:20:11.5389089Z Commit 5c305831a1c6187f4559399d8d4c825e83d09d18: OK
+guard	Commit message lint	2026-07-25T21:20:11.5389869Z Commit 23dacfb7bf9d93c2916e46af52a40f250fe6a9d8: OK
+guard	Commit message lint	2026-07-25T21:20:11.5390618Z Commit f019672618958f29090ed632581c358489a74c0d: OK
+guard	Commit message lint	2026-07-25T21:20:11.5391356Z Commit 2fcb1bb1f849cbcb8493bd81a41cac1d7476a5fd: OK
+guard	Commit message lint	2026-07-25T21:20:11.5392424Z Commit f966bc8dc70064c70dea0a2f3ed5c330d6711229: OK
+guard	Commit message lint	2026-07-25T21:20:11.5393245Z Commit 52de3e8120ae4a47c1584ea3370fe9cb41640cd9: OK
+guard	Commit message lint	2026-07-25T21:20:11.5394065Z Commit 6f51669ee15fcdb6d4fdcef0d87f93c87899bc0b: OK
+guard	Commit message lint	2026-07-25T21:20:11.5394845Z Commit 6316e52c8c201cb7d48b6fef12847fa94cb541f1: OK
+guard	Commit message lint	2026-07-25T21:20:11.5395682Z Commit 625d5b0fcf31d366f5eb5665257f7d55ceb13eb3: OK
+guard	Commit message lint	2026-07-25T21:20:11.5396433Z Commit 6dacc9e8d376fe195d48bd598160704190242d39: OK
+guard	Commit message lint	2026-07-25T21:20:11.5397193Z Commit message verification failed (30 commits).
+guard	Commit message lint	2026-07-25T21:20:11.5397944Z Commit b804d915c03f2857dd74bb1ee4fa72f4617dfa98: OK
+guard	Commit message lint	2026-07-25T21:20:11.5398693Z Commit e125fb58f5c30d5e93f653dfcbec02683f84f3ad: OK
+guard	Commit message lint	2026-07-25T21:20:11.5399285Z Commit d70145711ca49c26d115bfdb60dc904201bab2e5: OK
+guard	Commit message lint	2026-07-25T21:20:11.5399682Z Commit 44d943aa51b1adb7c99fbf39d30f8a8991324417: OK
+guard	Commit message lint	2026-07-25T21:20:11.5400098Z Commit c23b29ad648445c31dafc94012604ce2d34b7cff: OK
+guard	Commit message lint	2026-07-25T21:20:11.5400766Z Commit 01d4c73c1bc5c65ec3ee9b0076e4b7b0d6317c59: OK
+guard	Commit message lint	2026-07-25T21:20:11.5401541Z Commit 3de632165cb514f9549b7d0740e03e9c08409d03: OK
+guard	Commit message lint	2026-07-25T21:20:11.5402642Z Commit e679c34f8d412c4190a2fa3d964479ef246bd2da: OK
+guard	Commit message lint	2026-07-25T21:20:11.5403415Z Commit 9906907477561c9a030c5f31707407cecb77f23a: OK
+guard	Commit message lint	2026-07-25T21:20:11.5404167Z Commit 8e8cb8207ce26565c0777b8b5cb8efabe54a1329: OK
+guard	Commit message lint	2026-07-25T21:20:11.5404733Z Commit b14c48c56d3dbf2bbbd2989de362747921aa8668: OK
+guard	Commit message lint	2026-07-25T21:20:11.5405408Z Commit 73e29dbe231f1649db99874c50df904f182000fd: OK
+guard	Commit message lint	2026-07-25T21:20:11.5406178Z Commit fdcd193ce17a3e3548f429903b7fef181a508605: OK
+guard	Commit message lint	2026-07-25T21:20:11.5406945Z Commit 66243b56b5bfc9c7e99d2bf7ebf6cfe86994d494: OK
+guard	Commit message lint	2026-07-25T21:20:11.5407746Z Commit ca34ffed190a097079bb9e45c8cc0d17e63d1037: OK
+guard	Commit message lint	2026-07-25T21:20:11.5408552Z Commit 12913ea7a095a6f6ff6ea07f635356e7116bb2dd: OK
+guard	Commit message lint	2026-07-25T21:20:11.5409569Z Commit c1a974d0fcca74147c416fcc261070f7650bb831: OK
+guard	Commit message lint	2026-07-25T21:20:11.5410498Z Commit 73c241a34e30a11f8830e78e2899a780c0aa5dff: OK
+guard	Commit message lint	2026-07-25T21:20:11.5411214Z Commit f005f4c872490fcd1ada35ed2d5bd2fc091d491c: OK
+guard	Commit message lint	2026-07-25T21:20:11.5412215Z Commit 62682fa918c01068e158af1504987c04ddc7506b: OK
+guard	Commit message lint	2026-07-25T21:20:11.5413055Z Commit 50c19d082e69d66f37f3ef044808be0a431133c5: OK
+guard	Commit message lint	2026-07-25T21:20:11.5413793Z Commit 8e88ee2d9d79a85966ae001d9ce5731ba63d7d04: OK
+guard	Commit message lint	2026-07-25T21:20:11.5414537Z Commit 6e12a05a7317f6667542748c938b443cbb1496e0: OK
+guard	Commit message lint	2026-07-25T21:20:11.5415268Z Commit 0334c1126c6e1e1d26b986c450e0fc296e322eb6: OK
+guard	Commit message lint	2026-07-25T21:20:11.5415996Z Commit 9189cc2e630c05b60ea09588b9df71367616ee42: OK
+guard	Commit message lint	2026-07-25T21:20:11.5416747Z Commit d40056a971abf1751184ee0648b916cffe378eca: OK
+guard	Commit message lint	2026-07-25T21:20:11.5417512Z Commit cc0f1e153397038fdd2afc939b18a9eb47531fef: OK
+guard	Commit message lint	2026-07-25T21:20:11.5418274Z Commit 2180adb42a4bdd1acf56f9aa84d2be78aeb048bc: OK
+guard	Commit message lint	2026-07-25T21:20:11.5419036Z Commit 3bf3650c3c0428148215fd854c44a412511c5a1f: OK
+guard	Commit message lint	2026-07-25T21:20:11.5419823Z Commit e942290fbbe96df00f9a27d677b29ccb546912c4: OK
+guard	Commit message lint	2026-07-25T21:20:11.5433628Z ##[error]Process completed with exit code 5.

--- a/specs/proofs/repo/REPO-003/artefacts/run-30175493102-commit-lint-failure.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/run-30175493102-commit-lint-failure.txt
@@ -1,0 +1,94 @@
+guard	Commit message lint	﻿2026-07-25T21:23:33.3922625Z ##[group]Run BASE="$BASE_SHA"
+guard	Commit message lint	2026-07-25T21:23:33.3923270Z ^[[36;1mBASE="$BASE_SHA"^[[0m
+guard	Commit message lint	2026-07-25T21:23:33.3923646Z ^[[36;1m# A new branch reports an all-zero "before" sha rather than an empty one.^[[0m
+guard	Commit message lint	2026-07-25T21:23:33.3924178Z ^[[36;1mif [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then^[[0m
+guard	Commit message lint	2026-07-25T21:23:33.3924886Z ^[[36;1m  BASE=$(git rev-list --max-parents=0 HEAD | head -n 1)^[[0m
+guard	Commit message lint	2026-07-25T21:23:33.3925217Z ^[[36;1mfi^[[0m
+guard	Commit message lint	2026-07-25T21:23:33.3925556Z ^[[36;1mnode tools/spec/verify-commit-range.mjs --base "$BASE" --head "$HEAD_SHA"^[[0m
+guard	Commit message lint	2026-07-25T21:23:33.3972390Z shell: /usr/bin/bash -e {0}
+guard	Commit message lint	2026-07-25T21:23:33.3972854Z env:
+guard	Commit message lint	2026-07-25T21:23:33.3973166Z   BASE_SHA: 0000000000000000000000000000000000000000
+guard	Commit message lint	2026-07-25T21:23:33.3973509Z   HEAD_SHA: 847187f1b4b421832dea4ed23d5e220ce7133f2a
+guard	Commit message lint	2026-07-25T21:23:33.3973802Z ##[endgroup]
+guard	Commit message lint	2026-07-25T21:23:33.7008005Z Commit 847187f1b4b421832dea4ed23d5e220ce7133f2a: OK
+guard	Commit message lint	2026-07-25T21:23:33.7010517Z Commit 674293634979f409dcc74171cc55924eaea5a1f0: OK
+guard	Commit message lint	2026-07-25T21:23:33.7011498Z Commit a41bd8cd115ea38bed9424d09050a43f62a86c14: OK
+guard	Commit message lint	2026-07-25T21:23:33.7012225Z Commit 888c61219dfcb7b4c4e5942e93f5cab9749e2ea0: OK
+guard	Commit message lint	2026-07-25T21:23:33.7013197Z Commit 6698fca9768192baf4f757e466142fcba326a64e: OK
+guard	Commit message lint	2026-07-25T21:23:33.7013937Z Commit b03dd9b310bd68f5f73731441380fdb9e732939b: OK
+guard	Commit message lint	2026-07-25T21:23:33.7014644Z Commit abbd1629fe4da3166378e93218a1dcdc704c6a4e: OK
+guard	Commit message lint	2026-07-25T21:23:33.7015908Z Commit a401e6d2d5730b01801d2e9566df2370c1bc6847: No slice ID pattern (e.g., ABC-123) found in commit message
+guard	Commit message lint	2026-07-25T21:23:33.7017480Z Commit 590d9e821976beabd99fd9b29006f07dbd9a092a: No slice ID pattern (e.g., ABC-123) found in commit message
+guard	Commit message lint	2026-07-25T21:23:33.7019073Z Commit 6d252fb305ff34931868777b6622473fa6586150: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7020717Z Commit 0647d0f925066def91fcb5f77ecac08b475ee7ec: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7022353Z Commit 84f83455737086a66826a419c38da67822b34171: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7024188Z Commit 53887c2a5197a4072f8b7abbf189581f805b88f1: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7025813Z Commit 937fe7191bcea6b6daf4f02ead1082346ad63488: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7027398Z Commit c852496f55551062cd3e384ac41b7a297f0b9927: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7029050Z Commit 886110c4773c05418b5a6650d38f49591f5e2cc1: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7030634Z Commit a971b2b173bce786dadee68a787ebb02468800bb: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7032405Z Commit bcbfea1cee5f2281903f3d90414bc8d75335e7aa: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7034487Z Commit 13c560cf6db050111ad1c402dd58922fba9eb708: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7035934Z Commit 948f0ba3d2626b11edafa92cf6da639679d8db68: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7037497Z Commit 361c13651ad04ea84b721f311254b280dabf799f: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7038994Z Commit 654702582a299e80175cff4106db501f8dd8c289: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7040458Z Commit f9fcedd63c7b9e200a17a8a0c2e0839a72c371a2: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7042136Z Commit 6a11a306ae5598fde6adbff2eb224f08836a0912: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7044057Z Commit df4972687e5ecf4aaf9bc76510016e3c17e8b958: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7045692Z Commit 55d3e4daafe50221edf8e9d745f49aa9ceccb7c5: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7047015Z Commit 4617536c728ab0d0211104813b81893a4d51e8d8: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7047916Z Commit 2bd41e9ddfb0c9415fec06e5c65030f8703d2a91: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7048963Z Commit 9907c433d1fc8fbec50d1e2f6f831635528811df: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7049873Z Commit e09aa7327c8b44a2ae3d741686e8d0a3ece625d8: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7050791Z Commit 3c8c7a8a058ca71c62bad008cb4f5eeb66bee922: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7051703Z Commit 410775fb39c516a821d754cfbe07c8f12130d592: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7052633Z Commit 42f411a382d0995624aaea9c67f562e514e09f02: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7054020Z Commit 7651b5388bad88100b387841b0a7f364cba150de: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7054931Z Commit 934821c15ab5bf5ec85baece5cc049165cf6cf93: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7055846Z Commit ae17d7ccbd883c5b85b3dd07a143310c99d60a44: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7056757Z Commit 6d293a7a26b2452754b0ebbbe7803ec4724daca3: Missing conventional commit prefix (e.g., "docs(scope): message")
+guard	Commit message lint	2026-07-25T21:23:33.7057385Z Commit e9829b47d3e4e59b004e2a2099e26dce4bfd4f16: OK
+guard	Commit message lint	2026-07-25T21:23:33.7057798Z Commit fc3abf8595da352000d923af11e56bf3e8e99e74: OK
+guard	Commit message lint	2026-07-25T21:23:33.7058204Z Commit ccaea649388dfbc8f65e930151f572fc49aa2146: OK
+guard	Commit message lint	2026-07-25T21:23:33.7058583Z Commit 5c305831a1c6187f4559399d8d4c825e83d09d18: OK
+guard	Commit message lint	2026-07-25T21:23:33.7058964Z Commit 23dacfb7bf9d93c2916e46af52a40f250fe6a9d8: OK
+guard	Commit message lint	2026-07-25T21:23:33.7059384Z Commit f019672618958f29090ed632581c358489a74c0d: OK
+guard	Commit message lint	2026-07-25T21:23:33.7059766Z Commit 2fcb1bb1f849cbcb8493bd81a41cac1d7476a5fd: OK
+guard	Commit message lint	2026-07-25T21:23:33.7060158Z Commit f966bc8dc70064c70dea0a2f3ed5c330d6711229: OK
+guard	Commit message lint	2026-07-25T21:23:33.7060552Z Commit 52de3e8120ae4a47c1584ea3370fe9cb41640cd9: OK
+guard	Commit message lint	2026-07-25T21:23:33.7060937Z Commit 6f51669ee15fcdb6d4fdcef0d87f93c87899bc0b: OK
+guard	Commit message lint	2026-07-25T21:23:33.7061332Z Commit 6316e52c8c201cb7d48b6fef12847fa94cb541f1: OK
+guard	Commit message lint	2026-07-25T21:23:33.7061713Z Commit 625d5b0fcf31d366f5eb5665257f7d55ceb13eb3: OK
+guard	Commit message lint	2026-07-25T21:23:33.7062433Z Commit 6dacc9e8d376fe195d48bd598160704190242d39: OK
+guard	Commit message lint	2026-07-25T21:23:33.7063095Z Commit b804d915c03f2857dd74bb1ee4fa72f4617dfa98: OK
+guard	Commit message lint	2026-07-25T21:23:33.7063598Z Commit e125fb58f5c30d5e93f653dfcbec02683f84f3ad: OK
+guard	Commit message lint	2026-07-25T21:23:33.7063985Z Commit d70145711ca49c26d115bfdb60dc904201bab2e5: OK
+guard	Commit message lint	2026-07-25T21:23:33.7064373Z Commit 44d943aa51b1adb7c99fbf39d30f8a8991324417: OK
+guard	Commit message lint	2026-07-25T21:23:33.7064755Z Commit c23b29ad648445c31dafc94012604ce2d34b7cff: OK
+guard	Commit message lint	2026-07-25T21:23:33.7065143Z Commit 01d4c73c1bc5c65ec3ee9b0076e4b7b0d6317c59: OK
+guard	Commit message lint	2026-07-25T21:23:33.7065518Z Commit 3de632165cb514f9549b7d0740e03e9c08409d03: OK
+guard	Commit message lint	2026-07-25T21:23:33.7066063Z Commit e679c34f8d412c4190a2fa3d964479ef246bd2da: OK
+guard	Commit message lint	2026-07-25T21:23:33.7066795Z Commit 9906907477561c9a030c5f31707407cecb77f23a: OK
+guard	Commit message lint	2026-07-25T21:23:33.7067473Z Commit 8e8cb8207ce26565c0777b8b5cb8efabe54a1329: OK
+guard	Commit message lint	2026-07-25T21:23:33.7068016Z Commit b14c48c56d3dbf2bbbd2989de362747921aa8668: OK
+guard	Commit message lint	2026-07-25T21:23:33.7068400Z Commit 73e29dbe231f1649db99874c50df904f182000fd: OK
+guard	Commit message lint	2026-07-25T21:23:33.7068780Z Commit fdcd193ce17a3e3548f429903b7fef181a508605: OK
+guard	Commit message lint	2026-07-25T21:23:33.7069170Z Commit 66243b56b5bfc9c7e99d2bf7ebf6cfe86994d494: OK
+guard	Commit message lint	2026-07-25T21:23:33.7069564Z Commit ca34ffed190a097079bb9e45c8cc0d17e63d1037: OK
+guard	Commit message lint	2026-07-25T21:23:33.7069988Z Commit 12913ea7a095a6f6ff6ea07f635356e7116bb2dd: OK
+guard	Commit message lint	2026-07-25T21:23:33.7070443Z Commit c1a974d0fcca74147c416fcc261070f7650bb831: OK
+guard	Commit message lint	2026-07-25T21:23:33.7071082Z Commit message verification failed (30 commits).
+guard	Commit message lint	2026-07-25T21:23:33.7071480Z Commit 73c241a34e30a11f8830e78e2899a780c0aa5dff: OK
+guard	Commit message lint	2026-07-25T21:23:33.7071882Z Commit f005f4c872490fcd1ada35ed2d5bd2fc091d491c: OK
+guard	Commit message lint	2026-07-25T21:23:33.7072287Z Commit 62682fa918c01068e158af1504987c04ddc7506b: OK
+guard	Commit message lint	2026-07-25T21:23:33.7073044Z Commit 50c19d082e69d66f37f3ef044808be0a431133c5: OK
+guard	Commit message lint	2026-07-25T21:23:33.7073442Z Commit 8e88ee2d9d79a85966ae001d9ce5731ba63d7d04: OK
+guard	Commit message lint	2026-07-25T21:23:33.7073824Z Commit 6e12a05a7317f6667542748c938b443cbb1496e0: OK
+guard	Commit message lint	2026-07-25T21:23:33.7074199Z Commit 0334c1126c6e1e1d26b986c450e0fc296e322eb6: OK
+guard	Commit message lint	2026-07-25T21:23:33.7074575Z Commit 9189cc2e630c05b60ea09588b9df71367616ee42: OK
+guard	Commit message lint	2026-07-25T21:23:33.7074961Z Commit d40056a971abf1751184ee0648b916cffe378eca: OK
+guard	Commit message lint	2026-07-25T21:23:33.7075342Z Commit cc0f1e153397038fdd2afc939b18a9eb47531fef: OK
+guard	Commit message lint	2026-07-25T21:23:33.7075728Z Commit 2180adb42a4bdd1acf56f9aa84d2be78aeb048bc: OK
+guard	Commit message lint	2026-07-25T21:23:33.7076115Z Commit 3bf3650c3c0428148215fd854c44a412511c5a1f: OK
+guard	Commit message lint	2026-07-25T21:23:33.7076505Z Commit e942290fbbe96df00f9a27d677b29ccb546912c4: OK
+guard	Commit message lint	2026-07-25T21:23:33.7087673Z ##[error]Process completed with exit code 5.

--- a/specs/proofs/repo/REPO-003/artefacts/run-30194495011-pr-event-pass.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/run-30194495011-pr-event-pass.txt
@@ -1,0 +1,45 @@
+
+✓ fix/ci-first-push-commit-lint Guard & CI sunderam-tripathi/finspeed#5 · 30194495011
+Triggered via pull_request about 5 minutes ago
+
+JOBS
+✓ guard in 4m22s (ID 89773457568)
+- deploy-web in 0s (ID 89773816512)
+
+ANNOTATIONS
+! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+guard: .github#2
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Orders.jsx#120
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/OrderBuilder.jsx#55
+
+! 'Input' is defined but never used                                                                                                                                                                                                                                                      
+guard: apps/web/src/design/features/distributor/OrderBuilder.jsx#3
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Invoices.jsx#45
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Invoices.jsx#43
+
+! 'agingTotal' is assigned a value but never used                      
+guard: apps/web/src/design/features/distributor/Invoices.jsx#39
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Dashboard.jsx#81
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Auth.jsx#28
+
+! Expected an assignment or function call and instead saw an expression                                                                                                                                                                                                                  
+guard: apps/web/src/design/features/distributor/Auth.jsx#12
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Account.jsx#41
+
+
+For more information about a job, try: gh run view --job=<job-id>
+View this run on GitHub: https://github.com/sunderam-tripathi/finspeed/actions/runs/30194495011

--- a/specs/proofs/repo/REPO-003/artefacts/run-first-push-pass.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/run-first-push-pass.txt
@@ -1,0 +1,23 @@
+# Guard run 30176201286 — first push of fix/ci-first-push-commit-lint (event: push, before=all zeros)
+# https://github.com/sunderam-tripathi/finspeed/actions/runs/30176201286
+# Overall conclusion: success (all steps green). Commit message lint step log:
+guard	Commit message lint	﻿2026-07-25T21:45:32.4932238Z ##[group]Run BASE="$BASE_SHA"
+guard	Commit message lint	2026-07-25T21:45:32.4932579Z ^[[36;1mBASE="$BASE_SHA"^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4932986Z ^[[36;1m# A new branch reports an all-zero "before" sha rather than an empty^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4933761Z ^[[36;1m# one. Falling back to the root commit linted the entire history, and^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4934250Z ^[[36;1m# the legacy commits that predate the convention turned every first^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4934727Z ^[[36;1m# push of a branch red. Lint only what is new to the branch instead.^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4935206Z ^[[36;1mif [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4935630Z ^[[36;1m  git fetch --no-tags origin main^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4935942Z ^[[36;1m  BASE=$(git merge-base HEAD origin/main)^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4936254Z ^[[36;1mfi^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4936586Z ^[[36;1mnode tools/spec/verify-commit-range.mjs --base "$BASE" --head "$HEAD_SHA"^[[0m
+guard	Commit message lint	2026-07-25T21:45:32.4983160Z shell: /usr/bin/bash -e {0}
+guard	Commit message lint	2026-07-25T21:45:32.4983466Z env:
+guard	Commit message lint	2026-07-25T21:45:32.4983697Z   BASE_SHA: 0000000000000000000000000000000000000000
+guard	Commit message lint	2026-07-25T21:45:32.4984067Z   HEAD_SHA: b87f5aa56deb059e89ebb480920e0feda4f68dfe
+guard	Commit message lint	2026-07-25T21:45:32.4984374Z ##[endgroup]
+guard	Commit message lint	2026-07-25T21:45:32.8147864Z From https://github.com/sunderam-tripathi/finspeed
+guard	Commit message lint	2026-07-25T21:45:32.8148504Z  * branch            main       -> FETCH_HEAD
+guard	Commit message lint	2026-07-25T21:45:32.8631535Z Commit b87f5aa56deb059e89ebb480920e0feda4f68dfe: OK
+guard	Commit message lint	2026-07-25T21:45:32.8633174Z All commit messages look good

--- a/specs/proofs/repo/REPO-003/artefacts/run-normal-push-pass.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/run-normal-push-pass.txt
@@ -1,0 +1,25 @@
+# Guard run 30177048496 — push of 925964f (hardened step), normal path: reachable non-zero 'before'
+# https://github.com/sunderam-tripathi/finspeed/actions/runs/30177048496
+# Overall conclusion: success (all steps green). Commit message lint step log:
+guard	Commit message lint	﻿2026-07-25T22:11:59.7064661Z ##[group]Run BASE="$BASE_SHA"
+guard	Commit message lint	2026-07-25T22:11:59.7065029Z ^[[36;1mBASE="$BASE_SHA"^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7065397Z ^[[36;1m# A new branch reports an all-zero "before" sha rather than an empty^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7066088Z ^[[36;1m# one, and a force-push can report a "before" that no ref reaches any^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7066561Z ^[[36;1m# more, so the checkout never fetched it. Falling back to the root^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7067010Z ^[[36;1m# commit linted the entire history, and the legacy commits that^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7067471Z ^[[36;1m# predate the convention turned every first push of a branch red.^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7067930Z ^[[36;1m# Whenever the reported base is unusable, lint what is new to the^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7068305Z ^[[36;1m# branch relative to main instead.^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7068691Z ^[[36;1mif [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] \^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7069137Z ^[[36;1m  || ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7069530Z ^[[36;1m  git fetch --no-tags origin main^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7069840Z ^[[36;1m  BASE=$(git merge-base HEAD origin/main)^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7070143Z ^[[36;1mfi^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7070470Z ^[[36;1mnode tools/spec/verify-commit-range.mjs --base "$BASE" --head "$HEAD_SHA"^[[0m
+guard	Commit message lint	2026-07-25T22:11:59.7116844Z shell: /usr/bin/bash -e {0}
+guard	Commit message lint	2026-07-25T22:11:59.7117113Z env:
+guard	Commit message lint	2026-07-25T22:11:59.7117352Z   BASE_SHA: a14b873c536398331a7651a04ae42be0a09dd180
+guard	Commit message lint	2026-07-25T22:11:59.7117699Z   HEAD_SHA: 925964fc7146d36cf18aa495898e5bb4109b858d
+guard	Commit message lint	2026-07-25T22:11:59.7117987Z ##[endgroup]
+guard	Commit message lint	2026-07-25T22:11:59.7618833Z Commit 925964fc7146d36cf18aa495898e5bb4109b858d: OK
+guard	Commit message lint	2026-07-25T22:11:59.7620522Z All commit messages look good

--- a/specs/proofs/repo/REPO-003/artefacts/slice-index.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/slice-index.txt
@@ -1,0 +1,5 @@
+
+> spec:slice-index
+> node tools/spec/slice-index.mjs
+
+Index updated at specs/notes/indexes/slice-index.md

--- a/specs/proofs/repo/REPO-003/artefacts/unreachable-base-crash.txt
+++ b/specs/proofs/repo/REPO-003/artefacts/unreachable-base-crash.txt
@@ -1,0 +1,12 @@
+# repro: pre-hardening behaviour when 'before' is not fetchable (any history-rewriting force-push).
+# The verifier does not return a lint verdict — it crashes on the missing object:
+# node tools/spec/verify-commit-range.mjs --base 1111111111111111111111111111111111111111 --head HEAD
+fatal: Invalid revision range 1111111111111111111111111111111111111111..HEAD
+node:internal/errors:985
+  const err = new Error(message);
+              ^
+
+Error: Command failed: git rev-list --no-merges 1111111111111111111111111111111111111111..HEAD
+fatal: Invalid revision range 1111111111111111111111111111111111111111..HEAD
+
+# exit=1 (neither 0=pass nor 5=lint-fail: an infrastructure crash, red for reasons unrelated to the pushed commits)


### PR DESCRIPTION
## Summary

Closes out **REPO-003 — Unblock the guard workflow and restore CI checks**.

The commit-lint step fell back to the repository root commit whenever a push event reported an unusable `before` SHA (all zeros on branch creation; the old code crashed outright on an unreachable `before` after a force-push). That linted the entire history — 30 legacy commits predate the convention — so the first push of every branch was red (runs 30175379989, 30175493102). The fallback now routes every unusable-base class to `git fetch origin main` + `git merge-base HEAD origin/main`, linting only branch-new commits; a reachable `before` is used as reported.

## Verification

- Run **30176201286** — real all-zero `before` on a first push: fallback path, only the branch-new commit linted, all steps green.
- Run **30177048496** — reachable `before`: fallback skipped, only the pushed commit linted, all steps green.
- Local repros: old root-base produces CI's identical 30-commit failing set; merge-base base exits 0; unreachable-`before` crash reproduced and closed; per-class condition routing captured.
- Proof bundle: `specs/proofs/repo/REPO-003/` (README + artefacts, discipline-adherence section).

Deployment policy is deliberately unchanged: `deploy-web` stays opt-in behind `ENABLE_PRODUCTION_DEPLOY`, no Vercel secrets are configured, and the plan records the standing risk that the Production environment needs a required reviewer before that variable is ever armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)