### PR TITLE
chore(repo): retire stale ledger entries WEB-016, WEB-020/021, WEB-022

### DIFF
--- a/specs/notes/plans/web/WEB-016.md
+++ b/specs/notes/plans/web/WEB-016.md
@@ -19,3 +19,9 @@
 - [x] Cloudflare DNS + SSL/TLS instructions drafted and stored in repo.
 - [x] Verification + telemetry workflow captured (inc. parity stack + production evidence expectations).
 - [x] Proof artefact plan (logs, screenshots, RESULT markers) ready before closing slice.
+
+## 2026-07-26 ledger close-out
+
+- Every checklist item was completed when this slice was worked, but the ledger flip
+  was never made and the entry sat "active" for months. Marked done retroactively
+  during the 2026-07-26 stale-ledger cleanup; no outstanding work was identified.

--- a/specs/notes/plans/web/WEB-020.md
+++ b/specs/notes/plans/web/WEB-020.md
@@ -46,3 +46,11 @@
 - [ ] Defects and polish items triaged into follow-up slices or explicitly accepted as known issues.
 - [ ] Telemetry refreshed (`npm run spec:slice-index`, `npm run spec:progress`) with logs stored as artefacts.
 - [ ] Slice parked after proof acceptance.
+
+## 2026-07-26 superseded
+
+- The completed items (headed UAT runs and scoring for home, dealers, and support)
+  were executed against the pre-redesign-merge production build. The WEB-035/036
+  merges have since reached production via the Amplify main-branch connection, so the
+  remaining checklist items are void as scoped. Marked superseded; production UAT
+  should be re-planned as a new slice against the currently deployed build.

--- a/specs/notes/plans/web/WEB-021.md
+++ b/specs/notes/plans/web/WEB-021.md
@@ -46,3 +46,11 @@
 - [ ] Blocking and non-blocking issues triaged into follow-up slices or accepted explicitly, with issues tagged as Functional/Usability/Visual/Content and P0–P3.
 - [ ] Telemetry refreshed (`npm run spec:slice-index`, `npm run spec:progress`) with logs stored as artefacts.
 - [ ] Slice parked after proof acceptance.
+
+## 2026-07-26 superseded
+
+- The completed items (production walkthroughs and scoring for catalog, brand story,
+  testimonials, and blog) were executed against the pre-redesign-merge production
+  build. The WEB-035/036 merges have since reached production via the Amplify
+  main-branch connection, so the remaining checklist items are void as scoped.
+  Marked superseded; successor UAT should target the currently deployed build.

--- a/specs/notes/plans/web/WEB-022.md
+++ b/specs/notes/plans/web/WEB-022.md
@@ -33,3 +33,15 @@
 - [x] Proof artefacts captured and accepted
 - [x] Progress telemetry updated
 - [ ] Slice parked after commit and production proof
+
+## 2026-07-26 ledger close-out
+
+- All checklist items through the Amplify release, production smoke tests, and
+  duplicate-stack cleanup were completed and proven; only the final park step was
+  missed, leaving the ledger "active". Marked done retroactively during the
+  2026-07-26 stale-ledger cleanup.
+- Standing consequence recorded: the Amplify app (`d2h8tz7elv2xy8`, `ap-south-1`)
+  remains connected to `main` with auto-build, so every merge to `main` deploys to
+  `www.finspeed.online` after CI. The 2026-07-26 WEB-035/036 merges were observed
+  live in production through this path. Any future no-deploy policy must disable
+  auto-build on the Amplify branch, not only the opt-in CI deploy job.

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -154,7 +154,7 @@
           "id": "WEB-016",
           "domain": "web",
           "title": "Dealer locator deploy automation",
-          "status": "active"
+          "status": "done"
         },
         {
           "id": "WEB-017",
@@ -178,19 +178,19 @@
           "id": "WEB-020",
           "domain": "web",
           "title": "Production UAT — core journeys",
-          "status": "planned"
+          "status": "superseded"
         },
         {
           "id": "WEB-021",
           "domain": "web",
           "title": "Production UAT — catalog & content",
-          "status": "planned"
+          "status": "superseded"
         },
         {
           "id": "WEB-022",
           "domain": "web",
           "title": "Claude redesign integration and Amplify release",
-          "status": "active"
+          "status": "done"
         },
         {
           "id": "WEB-034",


### PR DESCRIPTION
## Summary

Bookkeeping cleanup of the four stale ledger entries, each grounded in its plan and proof record:

- **WEB-016 → done** — all checklist items were completed when the slice was worked; only the ledger flip was missed.
- **WEB-022 → done** — Amplify release, production smoke tests, and CloudFront/S3 stack cleanup were completed and proven; only the park step was missed. Its plan now records the standing consequence: the Amplify app auto-builds `main`, so **every merge deploys to www.finspeed.online** — the 2026-07-26 WEB-035/036 merges were observed live through this path. A future no-deploy policy must disable Amplify auto-build, not just the opt-in CI job.
- **WEB-020 / WEB-021 → superseded** — partial UAT evidence predates the WEB-035/036 merges now in production; remaining items are void as scoped. Successor production UAT should be planned against the currently deployed build.

Merging this PR will itself trigger an Amplify rebuild of identical application code (specs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)