### PR TITLE
ci(repo): REPO-004 align release documents with the Amplify production path

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -67,35 +67,11 @@ jobs:
           node tools/spec/progress.mjs || true
           node tools/spec/slice-index.mjs || true
 
-  deploy-web:
-    needs: guard
-    # Opt-in. No Vercel secrets are configured, so this job would fail on every
-    # push to main rather than deploy anything. It is also unguarded: the
-    # Production environment has no protection rules, so once VERCEL_TOKEN
-    # exists this deploys straight to production with no approval. Set the
-    # repository variable ENABLE_PRODUCTION_DEPLOY=true to arm it, and add a
-    # required reviewer on the Production environment first. Which host this
-    # should target — Vercel or Amplify — is still undecided.
-    if: github.ref == 'refs/heads/main' && vars.ENABLE_PRODUCTION_DEPLOY == 'true'
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Install
-        run: npm install
-      - name: Build web app for production
-        run: npm run deploy
-      - name: Deploy to Vercel (production)
-        working-directory: apps/web
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: npx vercel --prod --token "$VERCEL_TOKEN" --yes
+  # There is deliberately no deploy job in this workflow. Merging to main IS
+  # the production release: the AWS Amplify app "finspeed" (d2h8tz7elv2xy8,
+  # ap-south-1) is connected to main with auto-build and serves
+  # https://www.finspeed.online. Branch protection on main requires a pull
+  # request and a green "guard" check (admins included), so nothing reaches
+  # production without this workflow passing first. A second deploy path here
+  # would either double-deploy or drift from Amplify. Verification, rollback,
+  # and history: specs/runbooks/repo/release.md (REPO-004).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ pointer: "AGENTS/charter/global-charter.md"
 - Guard discipline is mandatory—active slice, plan, and proof artefacts are treated as gating systems, not suggestions.
 - Your knowledge base starts here and extends to the supporting charter modules, domain capsules, and slice supplements you explicitly load before work.
 - Authority flows from this contract; linked material only expands detail and never supersedes directives stated here.
-- You hold owner-level access across GCP (Cloud Run, Cloud Storage, IAM, etc.) and are expected to use gcloud/CLI workflows to deploy, inspect, and remediate production environments whenever required.
+- Production is the AWS Amplify app `finspeed` (`ap-south-1`) auto-building the protected `main` branch — merging to `main` is the release. Use the AWS CLI (after `aws sso login`) to inspect and remediate production per `specs/runbooks/repo/release.md`; there is no separate deploy command.
 - Every customer-facing slice must source the official Finspeed logo/wordmark and hero imagery from `_shared/assets/` and follow `specs/references/handoff/ui-ux-aesthetics.md` for the unified UI/UX guidance.
 - Always create a multi-step plan while working. **Non Negotiable**
 - Source of truth discipline: never stash or hide local work. Keep changes in-tree, commit or branch them intentionally, and avoid regressions caused by temporary stashing.
@@ -56,7 +56,7 @@ pointer: "AGENTS/charter/global-charter.md"
 | Privileged task handoff | Queue every `sudo` command via `node tools/dev/sudo-request.mjs request --command "<cmd>" --reason "<why>"`, deliver the generated script to the steward, and record acknowledgements in `specs/working-memory/sudo-queue.json`. | [Automation Matrix](AGENTS/charter/automation-matrix.md#automation-interface); `tools/dev/README.md` |
 | Proof discipline | Produce proof bundles (`specs/proofs/<domain>/...`) containing logs, artefacts, RESULT markers, proof acceptance. | [Proof & Telemetry Matrix](AGENTS/charter/proof-telemetry.md#proof--telemetry-contracts) |
 | Production context | Treat all edits as production-impacting; staging shortcuts are disallowed. | [Safety & Escalation](#safety--escalation) |
-| Credential hygiene | Fetch secrets only from Google Secret Manager (`anansol-devops`); prevent persistence in repos or shell history. | [Safety & Escalation](#safety--escalation) |
+| Credential hygiene | Secrets live only in Amplify environment variables and GitHub Actions secrets; never copy them into the repo, logs, or shell history. | [Safety & Escalation](#safety--escalation) |
 | Governance sync | Update slice ledger, active-slice metadata, and owning contract spec together when status/scope changes. | [Navigation Matrix](AGENTS/charter/navigation-matrix.md#navigation-matrix) |
 | Commit closure | Finalise proof acceptance, commit immediately, route REPO-001 syncs with lint + guard logs. | [Proof & Telemetry Matrix](AGENTS/charter/proof-telemetry.md#proof--telemetry-contracts); [Automation Matrix](AGENTS/charter/automation-matrix.md#automation-interface) |
 | Idle workflow | Park to IDLE, widen allow list, update specs/ledger, then activate new slice. | [Automation Matrix](AGENTS/charter/automation-matrix.md#automation-interface) |

--- a/specs/contracts/repo/json/spec.json
+++ b/specs/contracts/repo/json/spec.json
@@ -5,8 +5,19 @@
     "Ensure commits reference active slice IDs"
   ],
   "scope": {
-    "in": [".githooks/**", "tools/spec/**", "specs/contracts/repo/**", "specs/notes/plans/repo/**", "specs/proofs/repo/**", "AGENTS/**", "specs/project-progress/**"],
-    "out": ["apps/**", "pkg/**"]
+    "in": [
+      ".githooks/**",
+      "tools/spec/**",
+      "specs/contracts/repo/**",
+      "specs/notes/plans/repo/**",
+      "specs/proofs/repo/**",
+      "AGENTS/**",
+      "specs/project-progress/**"
+    ],
+    "out": [
+      "apps/**",
+      "pkg/**"
+    ]
   },
   "acceptance_criteria": [
     "Commit messages include active slice ID when ACTIVE",
@@ -50,6 +61,28 @@
         "specs/proofs/repo/REPO-002/**",
         "AGENTS/**",
         "specs/project-progress/**"
+      ]
+    },
+    {
+      "id": "REPO-004",
+      "title": "Align release documents with the Amplify production path",
+      "done_definition": [
+        "The unused Vercel deploy-web job is removed from CI and the workflow documents the real release path",
+        "A release runbook records the Amplify main-branch auto-deploy, the branch-protection gate, verification, and rollback",
+        "Charter claims that contradict the deployed infrastructure are corrected",
+        "Proof captures the green guard run demonstrating the workflow after the removal"
+      ],
+      "allow": [
+        ".github/workflows/**",
+        "specs/runbooks/repo/**",
+        "specs/contracts/repo/**",
+        "specs/notes/plans/repo/REPO-004.md",
+        "specs/proofs/repo/REPO-004/**",
+        "AGENTS.md",
+        "AGENTS/**",
+        "specs/notes/indexes/**",
+        "specs/project-progress/**",
+        "specs/working-memory/**"
       ]
     }
   ]

--- a/specs/notes/plans/repo/REPO-004.md
+++ b/specs/notes/plans/repo/REPO-004.md
@@ -44,10 +44,10 @@
 - [x] `deploy-web` removed; workflow comment documents the real release path.
 - [x] `specs/runbooks/repo/release.md` written and referenced from the workflow.
 - [x] Charter GCP-era claims corrected to the AWS reality.
-- [ ] Workflow proven by a green `guard` run on this branch's pull request.
-- [ ] Proof artefacts captured under `specs/proofs/repo/REPO-004/`.
-- [ ] Telemetry refreshed.
-- [ ] Slice parked.
+- [x] Workflow proven by a green `guard` run on this branch's pull request.
+- [x] Proof artefacts captured under `specs/proofs/repo/REPO-004/`.
+- [x] Telemetry refreshed.
+- [x] Slice parked.
 
 ## Follow-ups (not in this slice)
 - Full template-debt sweep of AGENTS.md and charter modules (docker parity stack is

--- a/specs/notes/plans/repo/REPO-004.md
+++ b/specs/notes/plans/repo/REPO-004.md
@@ -1,0 +1,59 @@
+# Plan — REPO-004
+
+- Context:
+  The repository's release documents contradict its live infrastructure. Production
+  `www.finspeed.online` is the AWS Amplify app `finspeed` (`d2h8tz7elv2xy8`,
+  `ap-south-1`) auto-building the `main` branch — established by WEB-022 and ratified
+  as deliberate policy on 2026-07-26, when `main` gained branch protection requiring a
+  pull request and a green `guard` check (admins enforced). Yet `guard.yml` still
+  carries a disarmed `deploy-web` job targeting Vercel whose own comment calls the
+  host "undecided", and the root charter still claims GCP infrastructure and Google
+  Secret Manager credential flows from the template this repo grew out of. The
+  2026-07-26 WEB-035/036 merges went live through the Amplify path while every
+  operator was watching only the disarmed CI job — the written record must stop
+  pointing away from the real release path.
+- Goals:
+  - Remove the unused Vercel `deploy-web` job so CI has no second, contradictory
+    deploy path, and document the real path where the job used to be.
+  - Write `specs/runbooks/repo/release.md`: production identity, the
+    merge-is-deploy gate, post-release verification, rollback, and the preview
+    integration's non-production role.
+  - Correct the charter's GCP-era claims (infrastructure access, secret manager)
+    to the AWS reality.
+- Risks:
+  - Editing `guard.yml` can break the workflow that branch protection now requires;
+    the PR's own guard run is the executable proof either way, and merge is blocked
+    until it passes.
+  - Deleting the job removes the `Production` GitHub environment's only reference;
+    the environment itself is left for the owner to delete in settings (optional).
+  - The charter edit is deliberately surgical — two false claims — because a full
+    template-debt rewrite (docker parity stub, sudo queue, GCP remnants elsewhere)
+    is its own slice.
+
+## Steps
+1. Delete the `deploy-web` job from `.github/workflows/guard.yml` and replace it
+   with a comment stating the Amplify release path and pointing at the runbook.
+2. Write `specs/runbooks/repo/release.md` covering identity, gate, verification,
+   rollback (requires `aws sso login`), previews, and history.
+3. Correct the charter's GCP infrastructure and Google Secret Manager lines to the
+   AWS Amplify / repository-secrets reality.
+4. Register REPO-004 in the repo contract spec and ledger; keep plan, proof, and
+   telemetry current; close through the guarded commit flow.
+
+## Execution Checklist
+- [x] `deploy-web` removed; workflow comment documents the real release path.
+- [x] `specs/runbooks/repo/release.md` written and referenced from the workflow.
+- [x] Charter GCP-era claims corrected to the AWS reality.
+- [ ] Workflow proven by a green `guard` run on this branch's pull request.
+- [ ] Proof artefacts captured under `specs/proofs/repo/REPO-004/`.
+- [ ] Telemetry refreshed.
+- [ ] Slice parked.
+
+## Follow-ups (not in this slice)
+- Full template-debt sweep of AGENTS.md and charter modules (docker parity stack is
+  a state-file stub, sudo-request queue is POSIX-era, remaining GCP references in
+  charter modules).
+- Optional: delete the now-unreferenced `Production` GitHub environment (owner
+  action in repository settings).
+- Successor production UAT slice against the live build (replaces superseded
+  WEB-020/021).

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -36,7 +36,7 @@
           "id": "REPO-004",
           "domain": "repo",
           "title": "Align release documents with the Amplify production path",
-          "status": "active"
+          "status": "done"
         }
       ]
     },

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -31,6 +31,12 @@
           "domain": "repo",
           "title": "Unblock the guard workflow and restore CI checks",
           "status": "done"
+        },
+        {
+          "id": "REPO-004",
+          "domain": "repo",
+          "title": "Align release documents with the Amplify production path",
+          "status": "active"
         }
       ]
     },

--- a/specs/proofs/repo/REPO-004/README.md
+++ b/specs/proofs/repo/REPO-004/README.md
@@ -20,9 +20,9 @@
 - Workflow YAML parses; `jobs` contains exactly `guard` (python `yaml.safe_load`).
 - `npm run spec:plan-lint -- specs/notes/plans/repo/REPO-004.md` — Plan lint OK.
 - `npm run spec:validate-references` — exit 0.
-- Green `guard` run on this branch's pull request: recorded in
-  `artefacts/` once the PR run completes (required by branch protection before
-  merge, so the merge itself is the enforcement).
+- Green `guard` runs on this branch (PR event and push event) executed the
+  edited workflow end to end: runs 30195473969 and 30195464195
+  (`artefacts/run-30195473969-guard-pass.txt`).
 
 ## Context
 
@@ -31,4 +31,4 @@ The 2026-07-26 WEB-035/036 merges deployed to production through the Amplify
 Branch protection (PR + `guard` + admins) was added the same day; this slice
 makes the written record match that machinery.
 
-final result: pending PR guard run; all local checks passed
+final result: passed

--- a/specs/proofs/repo/REPO-004/README.md
+++ b/specs/proofs/repo/REPO-004/README.md
@@ -1,0 +1,34 @@
+# REPO-004 Proof - Align release documents with the Amplify production path
+
+## What changed
+
+- `.github/workflows/guard.yml` — the disarmed Vercel `deploy-web` job is removed
+  and replaced with a comment documenting the real release path (Amplify
+  auto-build of protected `main`); the workflow now contains only the `guard`
+  job (`artefacts/guard-yml-deploy-job-removal.diff.txt`).
+- `specs/runbooks/repo/release.md` — new runbook: production identity, the
+  merge-is-deploy gate, post-release verification, rollback via the Amplify CLI
+  (requires `aws sso login`), the Vercel preview integration's non-production
+  role, and release-path history.
+- `AGENTS.md` — two template-era falsehoods corrected: GCP owner-access replaced
+  by the AWS Amplify release reality, and Google Secret Manager replaced by
+  Amplify environment variables / GitHub Actions secrets
+  (`artefacts/charter-gcp-corrections.diff.txt`).
+
+## Verification
+
+- Workflow YAML parses; `jobs` contains exactly `guard` (python `yaml.safe_load`).
+- `npm run spec:plan-lint -- specs/notes/plans/repo/REPO-004.md` — Plan lint OK.
+- `npm run spec:validate-references` — exit 0.
+- Green `guard` run on this branch's pull request: recorded in
+  `artefacts/` once the PR run completes (required by branch protection before
+  merge, so the merge itself is the enforcement).
+
+## Context
+
+The 2026-07-26 WEB-035/036 merges deployed to production through the Amplify
+`main` connection while operators were watching only the disarmed Vercel CI job.
+Branch protection (PR + `guard` + admins) was added the same day; this slice
+makes the written record match that machinery.
+
+final result: pending PR guard run; all local checks passed

--- a/specs/proofs/repo/REPO-004/artefacts/charter-gcp-corrections.diff.txt
+++ b/specs/proofs/repo/REPO-004/artefacts/charter-gcp-corrections.diff.txt
@@ -1,0 +1,22 @@
+diff --git a/AGENTS.md b/AGENTS.md
+index ef538c0..54cd2dc 100644
+--- a/AGENTS.md
++++ b/AGENTS.md
+@@ -26,7 +26,7 @@ pointer: "AGENTS/charter/global-charter.md"
+ - Guard discipline is mandatory—active slice, plan, and proof artefacts are treated as gating systems, not suggestions.
+ - Your knowledge base starts here and extends to the supporting charter modules, domain capsules, and slice supplements you explicitly load before work.
+ - Authority flows from this contract; linked material only expands detail and never supersedes directives stated here.
+-- You hold owner-level access across GCP (Cloud Run, Cloud Storage, IAM, etc.) and are expected to use gcloud/CLI workflows to deploy, inspect, and remediate production environments whenever required.
++- Production is the AWS Amplify app `finspeed` (`ap-south-1`) auto-building the protected `main` branch — merging to `main` is the release. Use the AWS CLI (after `aws sso login`) to inspect and remediate production per `specs/runbooks/repo/release.md`; there is no separate deploy command.
+ - Every customer-facing slice must source the official Finspeed logo/wordmark and hero imagery from `_shared/assets/` and follow `specs/references/handoff/ui-ux-aesthetics.md` for the unified UI/UX guidance.
+ - Always create a multi-step plan while working. **Non Negotiable**
+ - Source of truth discipline: never stash or hide local work. Keep changes in-tree, commit or branch them intentionally, and avoid regressions caused by temporary stashing.
+@@ -56,7 +56,7 @@ pointer: "AGENTS/charter/global-charter.md"
+ | Privileged task handoff | Queue every `sudo` command via `node tools/dev/sudo-request.mjs request --command "<cmd>" --reason "<why>"`, deliver the generated script to the steward, and record acknowledgements in `specs/working-memory/sudo-queue.json`. | [Automation Matrix](AGENTS/charter/automation-matrix.md#automation-interface); `tools/dev/README.md` |
+ | Proof discipline | Produce proof bundles (`specs/proofs/<domain>/...`) containing logs, artefacts, RESULT markers, proof acceptance. | [Proof & Telemetry Matrix](AGENTS/charter/proof-telemetry.md#proof--telemetry-contracts) |
+ | Production context | Treat all edits as production-impacting; staging shortcuts are disallowed. | [Safety & Escalation](#safety--escalation) |
+-| Credential hygiene | Fetch secrets only from Google Secret Manager (`anansol-devops`); prevent persistence in repos or shell history. | [Safety & Escalation](#safety--escalation) |
++| Credential hygiene | Secrets live only in Amplify environment variables and GitHub Actions secrets; never copy them into the repo, logs, or shell history. | [Safety & Escalation](#safety--escalation) |
+ | Governance sync | Update slice ledger, active-slice metadata, and owning contract spec together when status/scope changes. | [Navigation Matrix](AGENTS/charter/navigation-matrix.md#navigation-matrix) |
+ | Commit closure | Finalise proof acceptance, commit immediately, route REPO-001 syncs with lint + guard logs. | [Proof & Telemetry Matrix](AGENTS/charter/proof-telemetry.md#proof--telemetry-contracts); [Automation Matrix](AGENTS/charter/automation-matrix.md#automation-interface) |
+ | Idle workflow | Park to IDLE, widen allow list, update specs/ledger, then activate new slice. | [Automation Matrix](AGENTS/charter/automation-matrix.md#automation-interface) |

--- a/specs/proofs/repo/REPO-004/artefacts/guard-yml-deploy-job-removal.diff.txt
+++ b/specs/proofs/repo/REPO-004/artefacts/guard-yml-deploy-job-removal.diff.txt
@@ -1,0 +1,48 @@
+diff --git a/.github/workflows/guard.yml b/.github/workflows/guard.yml
+index 0a9b6c1..a8c1fa2 100644
+--- a/.github/workflows/guard.yml
++++ b/.github/workflows/guard.yml
+@@ -67,35 +67,11 @@ jobs:
+           node tools/spec/progress.mjs || true
+           node tools/spec/slice-index.mjs || true
+ 
+-  deploy-web:
+-    needs: guard
+-    # Opt-in. No Vercel secrets are configured, so this job would fail on every
+-    # push to main rather than deploy anything. It is also unguarded: the
+-    # Production environment has no protection rules, so once VERCEL_TOKEN
+-    # exists this deploys straight to production with no approval. Set the
+-    # repository variable ENABLE_PRODUCTION_DEPLOY=true to arm it, and add a
+-    # required reviewer on the Production environment first. Which host this
+-    # should target — Vercel or Amplify — is still undecided.
+-    if: github.ref == 'refs/heads/main' && vars.ENABLE_PRODUCTION_DEPLOY == 'true'
+-    runs-on: ubuntu-latest
+-    environment: production
+-    steps:
+-      - name: Checkout
+-        uses: actions/checkout@v4
+-        with:
+-          fetch-depth: 0
+-      - name: Setup Node
+-        uses: actions/setup-node@v4
+-        with:
+-          node-version: '22'
+-      - name: Install
+-        run: npm install
+-      - name: Build web app for production
+-        run: npm run deploy
+-      - name: Deploy to Vercel (production)
+-        working-directory: apps/web
+-        env:
+-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+-        run: npx vercel --prod --token "$VERCEL_TOKEN" --yes
++  # There is deliberately no deploy job in this workflow. Merging to main IS
++  # the production release: the AWS Amplify app "finspeed" (d2h8tz7elv2xy8,
++  # ap-south-1) is connected to main with auto-build and serves
++  # https://www.finspeed.online. Branch protection on main requires a pull
++  # request and a green "guard" check (admins included), so nothing reaches
++  # production without this workflow passing first. A second deploy path here
++  # would either double-deploy or drift from Amplify. Verification, rollback,
++  # and history: specs/runbooks/repo/release.md (REPO-004).

--- a/specs/proofs/repo/REPO-004/artefacts/run-30195473969-guard-pass.txt
+++ b/specs/proofs/repo/REPO-004/artefacts/run-30195473969-guard-pass.txt
@@ -1,0 +1,88 @@
+
+✓ chore/repo-004-release-docs Guard & CI sunderam-tripathi/finspeed#7 · 30195473969
+Triggered via pull_request about 6 minutes ago
+
+JOBS
+✓ guard in 5m53s (ID 89776129755)
+
+ANNOTATIONS
+! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+guard: .github#2
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Orders.jsx#120
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/OrderBuilder.jsx#55
+
+! 'Input' is defined but never used                                                                                                                                                                                                                                                      
+guard: apps/web/src/design/features/distributor/OrderBuilder.jsx#3
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Invoices.jsx#45
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Invoices.jsx#43
+
+! 'agingTotal' is assigned a value but never used                      
+guard: apps/web/src/design/features/distributor/Invoices.jsx#39
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Dashboard.jsx#81
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Auth.jsx#28
+
+! Expected an assignment or function call and instead saw an expression                                                                                                                                                                                                                  
+guard: apps/web/src/design/features/distributor/Auth.jsx#12
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Account.jsx#41
+
+
+For more information about the job, try: gh run view --job=89776129755
+View this run on GitHub: https://github.com/sunderam-tripathi/finspeed/actions/runs/30195473969
+
+✓ chore/repo-004-release-docs Guard & CI sunderam-tripathi/finspeed#7 · 30195464195
+Triggered via push about 7 minutes ago
+
+JOBS
+✓ guard in 6m8s (ID 89776101963)
+
+ANNOTATIONS
+! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+guard: .github#2
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Orders.jsx#120
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/OrderBuilder.jsx#55
+
+! 'Input' is defined but never used                                                                                                                                                                                                                                                      
+guard: apps/web/src/design/features/distributor/OrderBuilder.jsx#3
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Invoices.jsx#45
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Invoices.jsx#43
+
+! 'agingTotal' is assigned a value but never used                      
+guard: apps/web/src/design/features/distributor/Invoices.jsx#39
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Dashboard.jsx#81
+
+! Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element
+guard: apps/web/src/design/features/distributor/Auth.jsx#28
+
+! Expected an assignment or function call and instead saw an expression                                                                                                                                                                                                                  
+guard: apps/web/src/design/features/distributor/Auth.jsx#12
+
+! Expected an assignment or function call and instead saw an expression
+guard: apps/web/src/design/features/distributor/Account.jsx#41
+
+
+For more information about the job, try: gh run view --job=89776101963
+View this run on GitHub: https://github.com/sunderam-tripathi/finspeed/actions/runs/30195464195

--- a/specs/runbooks/repo/release.md
+++ b/specs/runbooks/repo/release.md
@@ -1,0 +1,62 @@
+# Release Runbook — finspeed.online
+
+## Production identity
+
+- Host: AWS Amplify, app `finspeed` (`d2h8tz7elv2xy8`), region `ap-south-1`,
+  account `660883642048`, platform `WEB_COMPUTE` (Next.js SSR).
+- Public domain: `https://finspeed.online` (redirects to `https://www.finspeed.online`).
+- Production branch: `main`, auto-build ON — established by WEB-022, which also
+  removed the legacy CloudFront/S3 stack.
+
+## Release path: merging to main IS the deploy
+
+Adopted as deliberate policy on 2026-07-26 (after the WEB-035/036 merges were
+observed live through this path while the disarmed CI deploy job pointed at the
+wrong host).
+
+1. All work lands via pull request. Branch protection on `main` requires a green
+   `guard` check (lint, production build, typecheck, unit tests, full Playwright
+   regression, reference validation) and applies to admins.
+2. On merge, Amplify auto-builds `main` and releases to production. There is no
+   separate deploy command, and deliberately no deploy job in CI.
+3. Treat every merge to `main` as a production release when proposing or
+   approving it.
+
+## Post-release verification
+
+- `https://www.finspeed.online/` returns 200.
+- Spot-check a content fingerprint of the release (e.g. an asset path introduced
+  by the merged change) rather than trusting the homepage alone; the WEB-035
+  release was confirmed via
+  `/assets/configurator/v1/bull-shark/side-r/light/poster/bull-shark-29-r01-w480.webp`.
+- The fuller smoke set from the original release is recorded in
+  `specs/proofs/web/WEB-022/artefacts/production-release.md`.
+
+## Rollback
+
+Requires AWS credentials (`aws sso login`; local sessions expire).
+
+```powershell
+aws amplify list-jobs --app-id d2h8tz7elv2xy8 --branch-name main --region ap-south-1 --max-items 10
+```
+
+Identify the last good job, then redeploy it from the Amplify console ("Redeploy
+this version") or via `aws amplify start-job --job-type RETRY --job-id <id>` with
+the same app/branch/region. Rolling back the deployment does not revert `main`;
+follow up with a revert PR so the branch and production reconverge.
+
+## Previews and non-production surfaces
+
+- The Vercel GitHub integration builds preview deployments for pull requests.
+  It is not the production path and deploys nothing to `finspeed.online`; it can
+  be uninstalled from the GitHub repository settings if unwanted.
+- The GitHub `Production` environment previously referenced by the deleted CI
+  deploy job is unused and may be removed in repository settings (owner action).
+
+## History
+
+- Legacy static SPA on CloudFront/S3 — replaced and removed by WEB-022.
+- Amplify `main` release established by WEB-022 (2026-07).
+- Disarmed Vercel `deploy-web` CI job added during the guard-restoration work and
+  removed by REPO-004 (2026-07-26) after the host contradiction surfaced.
+- Branch protection (PR + `guard` + admins) added 2026-07-26.


### PR DESCRIPTION
## Summary

**REPO-004** — the repo's release documents now match its live infrastructure.

- Remove the disarmed Vercel `deploy-web` job whose own comment called the host "undecided" while the Amplify `main` connection auto-deployed every merge (how the 2026-07-26 WEB-035/036 merges reached production unnoticed). The workflow now documents the real path in its place.
- New `specs/runbooks/repo/release.md`: production identity (Amplify `d2h8tz7elv2xy8`, `ap-south-1`), the merge-is-deploy gate under branch protection, post-release verification, rollback procedure, and the Vercel preview integration's non-production role.
- Charter corrections: GCP owner-access and Google Secret Manager claims replaced with the AWS Amplify / repository-secrets reality.

This PR's own green `guard` run is the executable proof of the edited workflow. Merging deploys identical application code (docs/CI-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)