### PR TITLE
chore(web): WEB-038 amplify audit, dormant rule removal, slice close

### DIFF
--- a/specs/notes/plans/web/WEB-038.md
+++ b/specs/notes/plans/web/WEB-038.md
@@ -94,12 +94,15 @@
 - [x] Locator entry points added; decision recorded.
 - [x] Server-title/404 Playwright coverage added; full suite green (73/73 in
       5.0m, recorded parity session; log in artefacts).
-- [ ] Amplify rule audit captured in proof (post `aws sso login`) — the one
-      open gate; slice stays active until it lands.
+- [x] Amplify rule audit captured in proof: dormant WEB-022-era
+      `/<*> → /index.html (404-200)` rule found, removal approved by the
+      steward, applied, and production re-verified 11/11 (before/after
+      captures in the proof). Credential mechanism corrected: `aws login`,
+      not `aws sso login`.
 - [x] Production verification after release; proof bundle assembled with
       WEB-037 re-adjudication (11/11 driver checks, screenshot inspected).
-- [ ] Telemetry refreshed and slice parked (after the audit closes the last
-      gate).
+- [x] Telemetry refreshed and slice parked after the audit closed the last
+      gate.
 
 ## Progress log
 - 2026-07-26 15:10 IST — Diagnosis evidence gathered (curl route sweep, RSC
@@ -147,3 +150,12 @@
   design-qa addendum recorded. Slice remains ACTIVE pending the sole open
   gate: the confirmatory Amplify rule audit under refreshed credentials;
   ledger deliberately not flipped to done.
+- 2026-07-26 16:55 IST — Audit closed the slice. Steward reauthenticated
+  (mechanism is `aws login`, not `aws sso login` — runbook drift noted in the
+  proof). Audit found the WEB-022-era `/<*> → /index.html (404-200)` rule:
+  the conditional variant, provably dormant (pre- and post-release probes
+  404 with the rule present), so it caused neither WEB-037 finding. Steward
+  approved removal; applied `update-app --custom-rules '[]'`; post-change
+  audit shows an empty rule set and `production-check.mjs` re-passed 11/11
+  with missing-asset probes still 404. Ledger flipped to done; telemetry
+  refreshed; slice parked after the close commit.

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -226,7 +226,7 @@
           "id": "WEB-038",
           "domain": "web",
           "title": "Per-route server titles, honest 404s, locator discoverability",
-          "status": "active"
+          "status": "done"
         }
       ]
     }

--- a/specs/proofs/web/WEB-038/README.md
+++ b/specs/proofs/web/WEB-038/README.md
@@ -96,17 +96,32 @@ testing that hypothesis against production and the code:
   (`Finspeed — Ride Beyond Boundaries`), per the recorded home-title
   decision.
 
-## Amplify delivery audit (requires `aws sso login`; appended when run)
+## Amplify delivery audit (run 2026-07-26 under refreshed credentials)
 
+- Credential note: this workstation authenticates with the AWS CLI v2
+  browser flow `aws login` (config `login_session`, account root), not
+  `aws sso login` as the release runbook stated.
 - `amplify-audit.mjs` — captures `get-app`/`get-branch` delivery configuration
-  (custom rules, platform, framework) with environment variables deliberately
-  stripped.
-- `amplify-rules.json` — captured configuration. Expected outcome per the
-  origin evidence above: no SPA-fallback rewrite. Any rule found is only
-  documented here; changing rules is out of this slice's executed scope and
-  needs explicit steward approval.
+  with environment variables deliberately stripped.
+- `amplify-rules-before.json` — the audit DID find the WEB-022-era rule:
+  `/<*> → /index.html (404-200)` — the **conditional** fallback variant, not
+  the rewrite-everything `200` rule. Consistent with the origin evidence, it
+  was dormant: it never fired for known routes, could not fire pre-WEB-038
+  (the catch-all answered every path 200), and measurably did not fire
+  post-WEB-038 either (unknown page paths and `/_next/static/nope.js` both
+  returned real 404s with the rule still present). It therefore caused
+  neither ISS-1 nor ISS-2.
+- Steward decision: **remove** (approved interactively 2026-07-26) — as a
+  legacy remnant it could only ever mask hard static-layer misses as
+  `200 /index.html`. Applied via
+  `aws amplify update-app --custom-rules '[]'` (delivery config only, no
+  rebuild).
+- `amplify-rules.json` — post-change capture: `customRules: []`, platform
+  `WEB_COMPUTE`, framework "Next.js - SSR", branch auto-build on.
+- Post-change verification: `production-check.mjs` re-run **11/11 pass**;
+  missing-asset probe still 404. No behavior change, config now honest.
 
-RESULT: PROVISIONAL PASS — parity gates green (73/73) and production
-verification green (11/11, screenshot inspected); the slice stays active
-until the confirmatory Amplify rule audit runs under refreshed AWS
-credentials (`aws sso login`) and its capture is appended here
+RESULT: PASS — parity gates green (73/73); production verification green
+(11/11 before and after the rule removal, screenshot inspected); Amplify
+delivery audit captured with the dormant WEB-022-era rule removed under
+explicit steward approval

--- a/specs/proofs/web/WEB-038/amplify-rules-before.json
+++ b/specs/proofs/web/WEB-038/amplify-rules-before.json
@@ -1,0 +1,27 @@
+{
+  "captured": "2026-07-26T11:19:08.339Z",
+  "app": {
+    "appId": "d2h8tz7elv2xy8",
+    "name": "finspeed",
+    "platform": "WEB_COMPUTE",
+    "defaultDomain": "d2h8tz7elv2xy8.amplifyapp.com",
+    "customRules": [
+      {
+        "source": "/<*>",
+        "target": "/index.html",
+        "status": "404-200"
+      }
+    ],
+    "customHeaders": "",
+    "enableBranchAutoBuild": false,
+    "buildSpecPresent": true
+  },
+  "branchMain": {
+    "branchName": "main",
+    "framework": "Next.js - SSR",
+    "stage": "PRODUCTION",
+    "enableAutoBuild": true,
+    "activeJobId": "0000000409"
+  },
+  "note": "environmentVariables and buildSpec contents deliberately omitted (secret hygiene)."
+}

--- a/specs/proofs/web/WEB-038/amplify-rules.json
+++ b/specs/proofs/web/WEB-038/amplify-rules.json
@@ -1,0 +1,21 @@
+{
+  "captured": "2026-07-26T11:20:33.187Z",
+  "app": {
+    "appId": "d2h8tz7elv2xy8",
+    "name": "finspeed",
+    "platform": "WEB_COMPUTE",
+    "defaultDomain": "d2h8tz7elv2xy8.amplifyapp.com",
+    "customRules": [],
+    "customHeaders": "",
+    "enableBranchAutoBuild": false,
+    "buildSpecPresent": true
+  },
+  "branchMain": {
+    "branchName": "main",
+    "framework": "Next.js - SSR",
+    "stage": "PRODUCTION",
+    "enableAutoBuild": true,
+    "activeJobId": "0000000409"
+  },
+  "note": "environmentVariables and buildSpec contents deliberately omitted (secret hygiene)."
+}

--- a/specs/proofs/web/WEB-038/artefacts/logs/spec-progress.txt
+++ b/specs/proofs/web/WEB-038/artefacts/logs/spec-progress.txt
@@ -8,3 +8,8 @@ Progress summary updated at specs/project-progress/progress-summary.json
 > node tools/spec/progress.mjs
 
 Progress summary updated at specs/project-progress/progress-summary.json
+
+> spec:progress
+> node tools/spec/progress.mjs
+
+Progress summary updated at specs/project-progress/progress-summary.json

--- a/specs/proofs/web/WEB-038/artefacts/logs/spec-slice-index.txt
+++ b/specs/proofs/web/WEB-038/artefacts/logs/spec-slice-index.txt
@@ -8,3 +8,8 @@ Index updated at specs/notes/indexes/slice-index.md
 > node tools/spec/slice-index.mjs
 
 Index updated at specs/notes/indexes/slice-index.md
+
+> spec:slice-index
+> node tools/spec/slice-index.mjs
+
+Index updated at specs/notes/indexes/slice-index.md

--- a/specs/proofs/web/WEB-038/production-results.json
+++ b/specs/proofs/web/WEB-038/production-results.json
@@ -1,6 +1,6 @@
 {
   "base": "https://www.finspeed.online",
-  "executed": "2026-07-26T10:23:59.129Z",
+  "executed": "2026-07-26T11:20:49.793Z",
   "checks": [
     {
       "name": "title /",


### PR DESCRIPTION
Closes the WEB-038 slice (two commits per the guarded close choreography):

1. **docs(web)** — Amplify audit captured under refreshed credentials (`aws login`; the runbook's `aws sso login` note was stale, corrected in the proof). The WEB-022-era `/<*> → /index.html (404-200)` rule existed but was provably dormant: unknown pages and missing static assets returned real 404s with it present, so it caused neither WEB-037 finding. Steward-approved removal applied (`update-app --custom-rules '[]'`); post-change audit shows an empty rule set; `production-check.mjs` re-passed 11/11. Proof RESULT: PASS with before/after captures.
2. **chore(web)** — ledger flip to done.

Docs + governance only; no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)