### PR TITLE
docs(repo): REPO-005 correct the AWS auth command in charter and runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ pointer: "AGENTS/charter/global-charter.md"
 - Guard discipline is mandatory—active slice, plan, and proof artefacts are treated as gating systems, not suggestions.
 - Your knowledge base starts here and extends to the supporting charter modules, domain capsules, and slice supplements you explicitly load before work.
 - Authority flows from this contract; linked material only expands detail and never supersedes directives stated here.
-- Production is the AWS Amplify app `finspeed` (`ap-south-1`) auto-building the protected `main` branch — merging to `main` is the release. Use the AWS CLI (after `aws sso login`) to inspect and remediate production per `specs/runbooks/repo/release.md`; there is no separate deploy command.
+- Production is the AWS Amplify app `finspeed` (`ap-south-1`) auto-building the protected `main` branch — merging to `main` is the release. Use the AWS CLI (after `aws login`, the CLI v2 browser flow — see the release runbook's credential note) to inspect and remediate production per `specs/runbooks/repo/release.md`; there is no separate deploy command.
 - Every customer-facing slice must source the official Finspeed logo/wordmark and hero imagery from `_shared/assets/` and follow `specs/references/handoff/ui-ux-aesthetics.md` for the unified UI/UX guidance.
 - Always create a multi-step plan while working. **Non Negotiable**
 - Source of truth discipline: never stash or hide local work. Keep changes in-tree, commit or branch them intentionally, and avoid regressions caused by temporary stashing.

--- a/specs/contracts/repo/json/spec.json
+++ b/specs/contracts/repo/json/spec.json
@@ -84,6 +84,24 @@
         "specs/project-progress/**",
         "specs/working-memory/**"
       ]
+    },
+    {
+      "id": "REPO-005",
+      "title": "Correct the AWS auth command in the charter and release runbook",
+      "done_definition": [
+        "Charter and release runbook state the working credential mechanism (aws login browser flow) instead of aws sso login",
+        "Proof records the evidence chain: the WEB-038 audit credential note and the failed aws sso login attempt"
+      ],
+      "allow": [
+        "AGENTS.md",
+        "specs/runbooks/repo/**",
+        "specs/contracts/repo/**",
+        "specs/notes/plans/repo/REPO-005.md",
+        "specs/proofs/repo/REPO-005/**",
+        "specs/notes/indexes/**",
+        "specs/project-progress/**",
+        "specs/working-memory/**"
+      ]
     }
   ]
 }

--- a/specs/notes/plans/repo/REPO-005.md
+++ b/specs/notes/plans/repo/REPO-005.md
@@ -1,0 +1,29 @@
+# Plan — REPO-005
+
+- Context:
+  The REPO-004 release runbook and charter told operators to authenticate with
+  `aws sso login`. The WEB-038 Amplify audit established that this workstation
+  actually authenticates with the AWS CLI v2 browser flow (`aws login`,
+  `login_session` configuration), and recorded the discrepancy in its proof; on
+  2026-07-27 the steward's `aws sso login` attempt failed with missing
+  `sso_start_url`/`sso_region`, confirming SSO was never configured here. A
+  wrong credential command in the rollback runbook is operational risk at the
+  worst possible moment.
+- Goals:
+  - State the working credential mechanism in the release runbook's rollback
+    section and the charter's production bullet.
+- Risks:
+  - None beyond documentation accuracy; no code, CI, or infrastructure changes.
+
+## Steps
+1. Correct the rollback credential note in `specs/runbooks/repo/release.md`.
+2. Correct the charter production bullet in `AGENTS.md`.
+3. Record the evidence chain in the proof and close through the guarded flow.
+
+## Execution Checklist
+- [x] Release runbook states `aws login` with the failure mode and recovery.
+- [x] Charter production bullet references the same mechanism.
+- [x] Proof records the WEB-038 credential note and the failed `aws sso login`
+      attempt as evidence.
+- [x] Telemetry refreshed.
+- [x] Slice parked.

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -37,6 +37,12 @@
           "domain": "repo",
           "title": "Align release documents with the Amplify production path",
           "status": "done"
+        },
+        {
+          "id": "REPO-005",
+          "domain": "repo",
+          "title": "Correct the AWS auth command in the charter and release runbook",
+          "status": "active"
         }
       ]
     },

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -42,7 +42,7 @@
           "id": "REPO-005",
           "domain": "repo",
           "title": "Correct the AWS auth command in the charter and release runbook",
-          "status": "active"
+          "status": "done"
         }
       ]
     },

--- a/specs/proofs/repo/REPO-005/README.md
+++ b/specs/proofs/repo/REPO-005/README.md
@@ -1,0 +1,27 @@
+# REPO-005 Proof - AWS auth command corrected in charter and release runbook
+
+## Evidence chain
+
+- The WEB-038 Amplify audit (2026-07-26) recorded: "this workstation
+  authenticates with the AWS CLI v2 browser flow `aws login` (config
+  `login_session`, account root), not `aws sso login` as the release runbook
+  stated" (`specs/proofs/web/WEB-038/README.md`, delivery-audit section).
+- On 2026-07-27 the steward's `aws sso login` attempt failed:
+  "Missing the following required SSO configuration values: sso_start_url,
+  sso_region" - confirming SSO was never configured on this machine.
+
+## Change
+
+- `specs/runbooks/repo/release.md` rollback section now states the `aws login`
+  browser flow, that `aws sso login` is unconfigured here, and the
+  expired-session recovery.
+- `AGENTS.md` production bullet references the same mechanism and points at the
+  runbook's credential note.
+
+## Verification
+
+- `grep -rn "aws sso login" AGENTS.md specs/runbooks/` returns no hits after
+  the change; the historical references in slice plans and proofs are records
+  of what was believed at the time and are deliberately left intact.
+
+final result: passed

--- a/specs/proofs/repo/REPO-005/README.md
+++ b/specs/proofs/repo/REPO-005/README.md
@@ -20,8 +20,10 @@
 
 ## Verification
 
-- `grep -rn "aws sso login" AGENTS.md specs/runbooks/` returns no hits after
-  the change; the historical references in slice plans and proofs are records
-  of what was believed at the time and are deliberately left intact.
+- `grep -rn "aws sso login" AGENTS.md specs/runbooks/` matches only the
+  runbook's explicit negation ("not `aws sso login`, which is unconfigured
+  here") — no document instructs its use. Historical references in slice plans
+  and proofs are records of what was believed at the time and are deliberately
+  left intact.
 
 final result: passed

--- a/specs/runbooks/repo/release.md
+++ b/specs/runbooks/repo/release.md
@@ -34,7 +34,10 @@ wrong host).
 
 ## Rollback
 
-Requires AWS credentials (`aws sso login`; local sessions expire).
+Requires AWS credentials. This workstation uses the AWS CLI v2 browser sign-in
+(`aws login`, `login_session` configuration — not `aws sso login`, which is
+unconfigured here; established during the WEB-038 Amplify audit). Sessions
+expire; re-run `aws login` when commands report an expired or missing session.
 
 ```powershell
 aws amplify list-jobs --app-id d2h8tz7elv2xy8 --branch-name main --region ap-south-1 --max-items 10


### PR DESCRIPTION
## Summary

**REPO-005** — two-line documentation erratum with an evidence chain: the WEB-038 Amplify audit established this workstation authenticates via the AWS CLI v2 browser flow (`aws login`, `login_session` config), and the steward's `aws sso login` attempt on 2026-07-27 failed with unconfigured SSO. The release runbook's rollback section and the charter's production bullet now state the working mechanism and the expired-session recovery.

Docs-only; merging deploys identical application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)