### PR TITLE
feat(web): WEB-039 move distributor pricing behind a server boundary

### DIFF
--- a/apps/web/src/app/api/distributor/portal/route.ts
+++ b/apps/web/src/app/api/distributor/portal/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { verifySessionToken } from '@/server/distributor-session';
+import { distributorPortalData } from '@/server/distributor-portal-data';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const authorization = request.headers.get('authorization') || '';
+  const token = authorization.startsWith('Bearer ') ? authorization.slice(7) : '';
+  if (!verifySessionToken(token)) {
+    return NextResponse.json(
+      { error: 'A distributor session is required.' },
+      { status: 401, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+  return NextResponse.json(
+    { portal: distributorPortalData },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/apps/web/src/app/api/distributor/session/route.ts
+++ b/apps/web/src/app/api/distributor/session/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { mintSessionToken } from '@/server/distributor-session';
+
+export const dynamic = 'force-dynamic';
+
+// Preview semantics, stated in the portal UI: credentials are not verified and
+// no live dealer account is opened, so a session is granted to any caller.
+// This handler is the single seam where real credential verification attaches
+// once dealer accounts exist; until then the token only moves the dataset off
+// the client bundle and behind an observable request boundary.
+export async function POST() {
+  const { token, expiresAt } = mintSessionToken();
+  return NextResponse.json(
+    { token, expiresAt },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/apps/web/src/design/data/distributor-boundary.test.mjs
+++ b/apps/web/src/design/data/distributor-boundary.test.mjs
@@ -1,0 +1,50 @@
+// WEB-039 boundary contract: dealer prices, margins, and portal records live
+// server-side only. This test fails if the data leaks back into the client
+// module or, when a production build is present, into any client chunk.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB_ROOT = path.resolve(HERE, '../../..');
+const CLIENT_MODULE = path.join(HERE, 'distributor.js');
+const CLIENT_CHUNKS = path.join(WEB_ROOT, '.next', 'static');
+
+// Strings that exist only in the server-side portal dataset. The sign-in
+// placeholder deliberately shows ravi@ravistores.in client-side, so that
+// address is NOT a valid sentinel.
+const SENTINELS = ['AABCR1234F', 'INV-8967', 'TK-3421', 'Neha Verma', 'dp: 3300'];
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+test('the client distributor module exports presentation helpers only', () => {
+  const source = readFileSync(CLIENT_MODULE, 'utf8');
+  for (const sentinel of SENTINELS) {
+    assert.equal(source.includes(sentinel), false, `client module contains server data sentinel "${sentinel}"`);
+  }
+  assert.equal(/\bdp\s*:/.test(source), false, 'client module carries dealer price fields');
+  assert.equal(/\bmargin\s*:/.test(source), false, 'client module carries margin fields');
+});
+
+test('no client chunk in the production build carries portal data', (t) => {
+  if (!existsSync(CLIENT_CHUNKS)) {
+    t.skip('no production build output at .next/static — run `npm run build -w web` first (CI builds before unit tests)');
+    return;
+  }
+  const chunks = [...walk(CLIENT_CHUNKS)].filter((file) => file.endsWith('.js'));
+  assert.ok(chunks.length > 0, 'expected client chunks in .next/static');
+  for (const chunk of chunks) {
+    const body = readFileSync(chunk, 'utf8');
+    for (const sentinel of SENTINELS) {
+      assert.equal(body.includes(sentinel), false, `${path.relative(WEB_ROOT, chunk)} contains "${sentinel}"`);
+    }
+  }
+});

--- a/apps/web/src/design/data/distributor.js
+++ b/apps/web/src/design/data/distributor.js
@@ -1,101 +1,16 @@
-// Finspeed Distributor Portal — data (from the Consolidated Pricing Matrix, 2024/25)
-// margin% is on retail: (retail - dp) / retail
-export const distributorProducts = [
-  { id:'red-snapper',       model:'Red Snapper',       variant:'24" Non IBC',   series:'Urban',      retail:4800,  dp:3300, margin:31.3, stock:'in' },
-  { id:'red-snapper',       model:'Red Snapper',       variant:'26" IBC',       series:'Urban',      retail:5500,  dp:3400, margin:38.2, stock:'in' },
-  { id:'sea-breeze',        model:'Sea Breeze',        variant:'26" IBC',       series:'Urban',      retail:5500,  dp:3400, margin:38.2, stock:'in' },
-  { id:'hammerhead',        model:'Hammerhead',        variant:'24"',           series:'Street',     retail:6000,  dp:3900, margin:35.0, stock:'in' },
-  { id:'great-white-shark', model:'Great White Shark', variant:'26"',           series:'Street',     retail:6300,  dp:4000, margin:36.5, stock:'low' },
-  { id:'tiger-shark',       model:'Tiger Shark',       variant:'24"',           series:'Tiger',      retail:6500,  dp:4800, margin:26.2, stock:'in' },
-  { id:'tiger-shark',       model:'Tiger Shark',       variant:'26"',           series:'Tiger',      retail:7700,  dp:5500, margin:28.6, stock:'in' },
-  { id:'lemon-shark',       model:'Lemon Shark',       variant:'27.5"',         series:'Big Wheel',  retail:8700,  dp:5700, margin:34.5, stock:'in' },
-  { id:'lightning-marlin',  model:'Lightning Marlin',  variant:'700C',          series:'Hybrid',     retail:9500,  dp:7000, margin:26.3, stock:'low' },
-  { id:'bull-shark',        model:'Bull Shark',        variant:'29"',           series:'Big Wheel',  retail:9500,  dp:5900, margin:37.9, stock:'in' },
-  { id:'shark-blue',        model:'Shark Blue',        variant:'26" Geared',    series:'Geared Elite', retail:9700, dp:7000, margin:27.8, stock:'in' },
-  { id:'mako-shark',        model:'Mako Shark',        variant:'27.5" Geared',  series:'Geared Elite', retail:10100, dp:7300, margin:27.7, stock:'out' },
-  { id:'sunset-marlin',     model:'Sunset Marlin',     variant:'700C Geared',   series:'Hybrid',     retail:10500, dp:7000, margin:33.3, stock:'in' },
-];
-
-export const distributorOrders = [
-  { no:'PO-2451', date:'12 Jun 2025', units:60,  value:228000, status:'Delivered' },
-  { no:'PO-2460', date:'24 Jun 2025', units:35,  value:171500, status:'In transit' },
-  { no:'PO-2477', date:'02 Jul 2025', units:48,  value:262400, status:'Processing' },
-  { no:'PO-2489', date:'09 Jul 2025', units:24,  value:141600, status:'Processing' },
-];
-
-// Credit / account terms for Ravi Stores (Tier 1)
-export const distributorAccount = {
-  legalName:'Ravi Stores',
-  tradeName:'Ravi Cycle Mart',
-  gstin:'09AABCR1234F1Z5',
-  pan:'AABCR1234F',
-  contact:'Ravi Kumar',
-  phone:'+91 98100 45678',
-  email:'ravi@ravistores.in',
-  since:'Mar 2019',
-  tier:'Tier 1',
-  terms:'Net 30',
-  creditLimit:1500000,
-  creditUsed:764400,
-  billing:{ line1:'Shop No. 14, Sector 18', line2:'Noida, Uttar Pradesh 201301' },
-  shipping:{ line1:'Plot 7, Phase 2, Sector 63', line2:'Noida, Uttar Pradesh 201307' },
-};
-
-export const distributorTeam = [
-  { name:'Ravi Kumar',    role:'Owner',      email:'ravi@ravistores.in',   access:'Full access',      you:true },
-  { name:'Anita Sharma',  role:'Purchasing', email:'anita@ravistores.in',  access:'Orders & invoices' },
-  { name:'Vikram Singh',  role:'Accounts',   email:'vikram@ravistores.in', access:'Invoices only' },
-];
-
-// Invoices (Net-30). paid = amount already settled.
-export const distributorInvoices = [
-  { no:'INV-8841', issued:'12 May 2025', due:'11 Jun 2025', po:'PO-2451', amount:228000, paid:228000, status:'Paid' },
-  { no:'INV-8902', issued:'24 May 2025', due:'23 Jun 2025', po:'PO-2460', amount:171500, paid:171500, status:'Paid' },
-  { no:'INV-8967', issued:'02 Jun 2025', due:'02 Jul 2025', po:'PO-2477', amount:262400, paid:0,      status:'Overdue' },
-  { no:'INV-9013', issued:'18 Jun 2025', due:'18 Jul 2025', po:'PO-2489', amount:141600, paid:0,      status:'Due' },
-  { no:'INV-9056', issued:'28 Jun 2025', due:'28 Jul 2025', po:'PO-2494', amount:98400,  paid:50000,  status:'Partial' },
-  { no:'INV-9090', issued:'06 Jul 2025', due:'05 Aug 2025', po:'PO-2501', amount:312000, paid:0,      status:'Due' },
-];
-
-// Support
-export const distributorRepresentative = {
-  name:'Neha Verma',
-  title:'Distributor Success Manager',
-  phone:'+91 99580 11234',
-  email:'neha.verma@finspeed.in',
-  sla:'Replies within 4 business hours',
-  hours:'Mon–Sat · 9:30–18:30 IST',
-};
-
-export const distributorTickets = [
-  { id:'TK-3421', subject:'Warranty claim — Mako Shark fork play', category:'Warranty',    status:'In progress', updated:'2 days ago' },
-  { id:'TK-3398', subject:'Missing spares carton in PO-2477',      category:'Order issue', status:'Resolved',    updated:'6 days ago' },
-  { id:'TK-3375', subject:'GST invoice correction — INV-8902',     category:'Billing',     status:'Resolved',    updated:'12 days ago' },
-];
-
-export const distributorFaq = [
-  { q:'Warranty & claims', a:'Frames carry a 5-year structural warranty; components 12 months. Raise a Warranty ticket with the model, variant and serial — replacements dispatch ex-works within 5 working days of approval.' },
-  { q:'Returns & replacements', a:'Transit-damaged units are replaced free when reported within 48 hours of delivery with photos. Stock returns are accepted within 30 days at 90% of DP for unused, boxed units.' },
-  { q:'Spares & accessories ordering', a:'Spares ship against the same Net-30 terms as cycles. Use the Order builder for forks, wheelsets and drivetrain kits, or raise a Spares ticket for items not in the matrix.' },
-  { q:'Payment terms & credit', a:'Tier-1 accounts run on Net-30 from invoice date. Credit limits are reviewed quarterly against trailing volume — request an increase through your success manager.' },
-  { q:'Dispatch & logistics', a:'All orders dispatch ex-works Greater Noida. FTL freight is arranged on request and billed at actuals; LTL consignments are insured to destination.' },
-];
-
+// Finspeed Distributor Portal — client-safe presentation helpers only.
+// The portal dataset (dealer prices, margins, orders, account, invoices,
+// tickets) moved server-side in WEB-039 and is served exclusively by
+// /api/distributor/portal behind a session token; nothing price-bearing may
+// be exported from this module.
 export const distributorProductImage = (id) => `/assets/products/upscaled/${id}-480.webp`;
 export const formatInr = (n) => '₹' + Number(n).toLocaleString('en-IN');
 
 // B2B fulfilment stages (index = current step)
-export const distributorTrackingStages = ['Confirmed','In production','Dispatched','In transit','Delivered'];
+export const distributorTrackingStages = ['Confirmed', 'In production', 'Dispatched', 'In transit', 'Delivered'];
 // status -> tracking step + badge tone
 export const distributorStatus = {
-  'Processing': { step:1, tone:'neutral' },
-  'In transit': { step:3, tone:'brand' },
-  'Delivered':  { step:4, tone:'success' },
-};
-// richer order rows for the Orders screen (lines + ETA)
-export const distributorOrderDetails = {
-  'PO-2451': { eta:'Delivered 18 Jun', lines:[['bull-shark','29"',30],['red-snapper','24" Non IBC',30]] },
-  'PO-2460': { eta:'Arriving 28 Jun', lines:[['tiger-shark','26"',20],['sea-breeze','26" IBC',15]] },
-  'PO-2477': { eta:'Ships 27 Jun', lines:[['mako-shark','27.5" Geared',24],['shark-blue','26" Geared',24]] },
-  'PO-2489': { eta:'Ships 30 Jun', lines:[['lemon-shark','27.5"',12],['lightning-marlin','700C',12]] },
+  'Processing': { step: 1, tone: 'neutral' },
+  'In transit': { step: 3, tone: 'brand' },
+  'Delivered': { step: 4, tone: 'success' },
 };

--- a/apps/web/src/design/features/distributor/Account.jsx
+++ b/apps/web/src/design/features/distributor/Account.jsx
@@ -1,7 +1,7 @@
 // Finspeed Distributor Portal — Account (business profile, credit, addresses, team)
 import React from 'react';
 import { Button, Input, Badge, IconButton } from '../../ui/index.js';
-import { distributorAccount, distributorTeam, formatInr } from '../../data/distributor.js';
+import { formatInr } from '../../data/distributor.js';
 import { useLucideIcons } from '../../lib/useLucideIcons.js';
 
 function Field({ label, value }) {
@@ -25,7 +25,8 @@ function Card({ title, action, children, pad=22 }) {
   );
 }
 
-function Account({ notify }) {
+function Account({ portal, notify }) {
+  const { account: distributorAccount, team: distributorTeam } = portal;
   const INR = formatInr;
   const A = distributorAccount;
   const team = distributorTeam;

--- a/apps/web/src/design/features/distributor/Auth.jsx
+++ b/apps/web/src/design/features/distributor/Auth.jsx
@@ -106,7 +106,7 @@ function DistAuth({ onEnter }) {
                 <Input label="Phone" placeholder="+91 98100 45678" required />
                 <div style={{ gridColumn:'1 / -1' }}><Input label="Email" type="email" placeholder="you@store.in" required /></div>
                 <Input label="City" placeholder="Noida" required />
-                <Input label="GSTIN" placeholder="09AABCR1234F1Z5" required />
+                <Input label="GSTIN" placeholder="07ABCDE1234F1Z5" required />
                 <div style={{ gridColumn:'1 / -1', marginTop:'var(--space-2)' }}>
                   <Button type="submit" variant="primary" size="lg" full iconRight={<i data-lucide="send" style={{width:17,height:17}}></i>}>Submit application</Button>
                 </div>

--- a/apps/web/src/design/features/distributor/Dashboard.jsx
+++ b/apps/web/src/design/features/distributor/Dashboard.jsx
@@ -1,14 +1,15 @@
 // Finspeed Distributor Portal — Dashboard
 import React from 'react';
 import { Badge } from '../../ui/index.js';
-import { distributorOrders, distributorProductImage, distributorProducts, formatInr } from '../../data/distributor.js';
+import { distributorProductImage, formatInr } from '../../data/distributor.js';
 
 function StatusBadge({ s }) {
   const map = { 'Delivered':'success', 'In transit':'brand', 'Processing':'warning' };
   return <Badge tone={map[s]||'neutral'} dot>{s}</Badge>;
 }
 
-function Dashboard({ onNav }) {
+function Dashboard({ portal, onNav }) {
+  const { orders: distributorOrders, products: distributorProducts } = portal;
   const D = distributorProducts, INR = formatInr;
   const avgMargin = (D.reduce((s,r)=>s+r.margin,0)/D.length).toFixed(1);
   const kpis = [

--- a/apps/web/src/design/features/distributor/DistributorApp.jsx
+++ b/apps/web/src/design/features/distributor/DistributorApp.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { Toast } from '../../ui/index.js';
-import { distributorOrderDetails, distributorProducts } from '../../data/distributor.js';
+import { fetchPortal, openPortalSession } from './portal-session.js';
 import { useLucideIcons } from '../../lib/useLucideIcons.js';
 import { usePersistentState } from '../../lib/usePersistentState.js';
 import Account from './Account.jsx';
@@ -56,8 +56,30 @@ export default function DistributorApp() {
   const toastTimer = React.useRef(null);
   // The portal is gated on an in-session sign-in rather than on the current
   // path, so a deep link cannot render dealer pricing to a visitor who never
-  // signed in. A reload returns to the sign-in screen by design.
+  // signed in. A reload returns to the sign-in screen by design. Since
+  // WEB-039 the dataset itself lives server-side: sign-in opens a session
+  // token and the portal payload is fetched over it, so pricing is never in
+  // the client bundle.
   const [authenticated, setAuthenticated] = React.useState(false);
+  const [portal, setPortal] = React.useState(null);
+  const [portalError, setPortalError] = React.useState(null);
+  const sessionToken = React.useRef(null);
+
+  const loadPortal = React.useCallback(async () => {
+    setPortalError(null);
+    try {
+      if (!sessionToken.current) sessionToken.current = await openPortalSession();
+      try {
+        setPortal(await fetchPortal(sessionToken.current));
+      } catch (error) {
+        if (!error.expired) throw error;
+        sessionToken.current = await openPortalSession();
+        setPortal(await fetchPortal(sessionToken.current));
+      }
+    } catch {
+      setPortalError('The portal data could not be loaded.');
+    }
+  }, []);
   const atSignIn = normalizedPath === '/distributor/sign-in';
   const signedOut = !authenticated;
 
@@ -101,6 +123,9 @@ export default function DistributorApp() {
       return next;
     });
   }
+
+  const distributorProducts = portal?.products ?? [];
+  const distributorOrderDetails = portal?.orderDetails ?? {};
 
   function reorder(purchaseOrder) {
     const detail = purchaseOrder.detail || distributorOrderDetails[purchaseOrder.no];
@@ -153,10 +178,28 @@ export default function DistributorApp() {
 
   if (signedOut) {
     if (!atSignIn) return <Navigate to="/distributor/sign-in" replace />;
-    return <Auth onEnter={() => { setAuthenticated(true); navigate('/distributor'); }} />;
+    return <Auth onEnter={() => { setAuthenticated(true); loadPortal(); navigate('/distributor'); }} />;
   }
 
   if (atSignIn) return <Navigate to="/distributor" replace />;
+
+  if (!portal) {
+    return (
+      <div className="dist-app-shell" style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-page)' }}>
+        <div role="status" style={{ textAlign: 'center', maxWidth: 420, padding: 'var(--space-6)' }}>
+          <div style={{ font: 'var(--fw-medium) var(--fs-2xs)/1 var(--font-mono)', letterSpacing: 'var(--tracking-wider)', textTransform: 'uppercase', color: 'var(--cyan-electric)' }}>Distributor portal</div>
+          <p style={{ font: 'var(--text-body-md)', color: 'var(--text-secondary)', margin: 'var(--space-4) 0 0' }}>
+            {portalError || 'Loading your pricing, orders and account…'}
+          </p>
+          {portalError ? (
+            <button type="button" className="btn btn--primary" style={{ marginTop: 'var(--space-5)' }} onClick={loadPortal}>
+              Try again
+            </button>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
 
   const [title, subtitle] = headings[route];
   const orderCount = Object.keys(order).length;
@@ -164,18 +207,18 @@ export default function DistributorApp() {
 
   return (
     <div className="dist-app-shell" style={{ display: 'flex', minHeight: '100vh', background: 'var(--bg-page)' }}>
-      <Sidebar route={route} onNav={setRoute} orderCount={orderCount} onSignOut={() => { setAuthenticated(false); navigate('/distributor/sign-in'); }} />
+      <Sidebar route={route} onNav={setRoute} orderCount={orderCount} onSignOut={() => { setAuthenticated(false); setPortal(null); setPortalError(null); sessionToken.current = null; navigate('/distributor/sign-in'); }} />
       <div className="dist-main" style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
         <Topbar title={title} subtitle={subtitle} query={query} onSearch={setQuery} />
         <div className="dist-route-body" style={{ flex: 1, minWidth: 0 }}>
           <Routes>
-            <Route index element={<Dashboard onNav={setRoute} />} />
-            <Route path="price-list" element={<PriceList query={query} order={order} onAdd={addToOrder} onNav={setRoute} />} />
-            <Route path="order-builder" element={<OrderBuilder order={order} onAdd={addToOrder} onRemove={removeLine} onNav={setRoute} onPlace={placeOrder} />} />
-            <Route path="orders" element={<Orders justPlaced={justPlaced} placedOrders={placedOrders} onClearPlaced={() => setJustPlaced(null)} onNav={setRoute} onReorder={reorder} />} />
-            <Route path="invoices" element={<Invoices notify={notify} />} />
-            <Route path="account" element={<Account notify={notify} />} />
-            <Route path="support" element={<Support notify={notify} />} />
+            <Route index element={<Dashboard portal={portal} onNav={setRoute} />} />
+            <Route path="price-list" element={<PriceList portal={portal} query={query} order={order} onAdd={addToOrder} onNav={setRoute} />} />
+            <Route path="order-builder" element={<OrderBuilder portal={portal} order={order} onAdd={addToOrder} onRemove={removeLine} onNav={setRoute} onPlace={placeOrder} />} />
+            <Route path="orders" element={<Orders portal={portal} justPlaced={justPlaced} placedOrders={placedOrders} onClearPlaced={() => setJustPlaced(null)} onNav={setRoute} onReorder={reorder} />} />
+            <Route path="invoices" element={<Invoices portal={portal} notify={notify} />} />
+            <Route path="account" element={<Account portal={portal} notify={notify} />} />
+            <Route path="support" element={<Support portal={portal} notify={notify} />} />
             <Route path="*" element={<Navigate to="/distributor" replace />} />
           </Routes>
         </div>

--- a/apps/web/src/design/features/distributor/Invoices.jsx
+++ b/apps/web/src/design/features/distributor/Invoices.jsx
@@ -1,7 +1,7 @@
 // Finspeed Distributor Portal — Invoices (Net-30 ledger)
 import React from 'react';
 import { Badge, Button, IconButton, Tag } from '../../ui/index.js';
-import { distributorAccount, distributorInvoices, formatInr } from '../../data/distributor.js';
+import { formatInr } from '../../data/distributor.js';
 import { useLucideIcons } from '../../lib/useLucideIcons.js';
 
 function InvStatus({ s }) {
@@ -9,7 +9,8 @@ function InvStatus({ s }) {
   return <Badge tone={map[s]||'neutral'} dot>{s}</Badge>;
 }
 
-function Invoices({ notify }) {
+function Invoices({ portal, notify }) {
+  const { account: distributorAccount, invoices: distributorInvoices } = portal;
   const INR = formatInr;
   const A = distributorAccount;
   const [rows, setRows] = React.useState(distributorInvoices);

--- a/apps/web/src/design/features/distributor/OrderBuilder.jsx
+++ b/apps/web/src/design/features/distributor/OrderBuilder.jsx
@@ -1,9 +1,10 @@
 // Finspeed Distributor Portal — Order builder
 import React from 'react';
 import { Button, QuantityStepper, Input, IconButton } from '../../ui/index.js';
-import { distributorProductImage, distributorProducts, formatInr } from '../../data/distributor.js';
+import { distributorProductImage, formatInr } from '../../data/distributor.js';
 
-function OrderBuilder({ order, onAdd, onRemove, onNav, onPlace }) {
+function OrderBuilder({ portal, order, onAdd, onRemove, onNav, onPlace }) {
+  const { products: distributorProducts } = portal;
   const D = distributorProducts, INR = formatInr;
   const wrapRef = React.useRef(null);
   const [narrow, setNarrow] = React.useState(false);

--- a/apps/web/src/design/features/distributor/Orders.jsx
+++ b/apps/web/src/design/features/distributor/Orders.jsx
@@ -1,18 +1,11 @@
 // Finspeed Distributor Portal — Orders (confirmation + history + tracking)
 import React from 'react';
 import { Button, Badge, IconButton } from '../../ui/index.js';
-import {
-  distributorOrderDetails,
-  distributorOrders,
-  distributorProductImage,
-  distributorProducts,
-  distributorStatus,
-  distributorTrackingStages,
-  formatInr,
-} from '../../data/distributor.js';
+import { distributorProductImage, distributorStatus, distributorTrackingStages, formatInr } from '../../data/distributor.js';
 import { useLucideIcons } from '../../lib/useLucideIcons.js';
 
-function DistOrders({ justPlaced, placedOrders = [], onClearPlaced, onNav, onReorder }) {
+function DistOrders({ portal, justPlaced, placedOrders = [], onClearPlaced, onNav, onReorder }) {
+  const { orderDetails: distributorOrderDetails, orders: distributorOrders, products: distributorProducts } = portal;
   const INR = formatInr;
   const STAGES = distributorTrackingStages;
   const SMAP = distributorStatus;

--- a/apps/web/src/design/features/distributor/PriceList.jsx
+++ b/apps/web/src/design/features/distributor/PriceList.jsx
@@ -1,7 +1,7 @@
 // Finspeed Distributor Portal — Price list (consolidated pricing matrix)
 import React from 'react';
 import { Tag, QuantityStepper, Button, Badge } from '../../ui/index.js';
-import { distributorProductImage, distributorProducts, formatInr } from '../../data/distributor.js';
+import { distributorProductImage, formatInr } from '../../data/distributor.js';
 
 function StockTag({ s }) {
   if (s==='in') return <Badge tone="success" dot>In stock</Badge>;
@@ -9,7 +9,8 @@ function StockTag({ s }) {
   return <Badge tone="danger" dot>Out</Badge>;
 }
 
-function PriceList({ query, order, onAdd, onNav }) {
+function PriceList({ portal, query, order, onAdd, onNav }) {
+  const { products: distributorProducts } = portal;
   const D = distributorProducts, INR = formatInr;
   const [series, setSeries] = React.useState('All');
   const allSeries = ['All', ...Array.from(new Set(D.map(r=>r.series)))];

--- a/apps/web/src/design/features/distributor/Support.jsx
+++ b/apps/web/src/design/features/distributor/Support.jsx
@@ -1,7 +1,6 @@
 // Finspeed Distributor Portal — Support (rep, raise ticket, tickets, FAQ)
 import React from 'react';
 import { Button, Input, Select, Badge, Accordion, IconButton } from '../../ui/index.js';
-import { distributorFaq, distributorRepresentative, distributorTickets } from '../../data/distributor.js';
 import { useLucideIcons } from '../../lib/useLucideIcons.js';
 
 function TicketStatus({ s }) {
@@ -9,7 +8,8 @@ function TicketStatus({ s }) {
   return <Badge tone={map[s]||'neutral'} dot>{s}</Badge>;
 }
 
-function Support({ notify }) {
+function Support({ portal, notify }) {
+  const { faq: distributorFaq, representative: distributorRepresentative, tickets: distributorTickets } = portal;
   const REP = distributorRepresentative;
   const FAQ = distributorFaq;
   const [tickets, setTickets] = React.useState(distributorTickets);

--- a/apps/web/src/design/features/distributor/portal-session.js
+++ b/apps/web/src/design/features/distributor/portal-session.js
@@ -1,0 +1,26 @@
+// Client access to the distributor portal dataset (WEB-039).
+// The dataset itself lives server-side; these calls are the only way the
+// portal obtains dealer pricing. Sessions are in-memory by design — a reload
+// returns to sign-in, matching the portal's honest preview semantics.
+
+export async function openPortalSession() {
+  const response = await fetch('/api/distributor/session', { method: 'POST' });
+  if (!response.ok) throw new Error(`session request failed (${response.status})`);
+  const { token } = await response.json();
+  if (!token) throw new Error('session response carried no token');
+  return token;
+}
+
+export async function fetchPortal(token) {
+  const response = await fetch('/api/distributor/portal', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (response.status === 401) {
+    const error = new Error('portal session expired');
+    error.expired = true;
+    throw error;
+  }
+  if (!response.ok) throw new Error(`portal request failed (${response.status})`);
+  const { portal } = await response.json();
+  return portal;
+}

--- a/apps/web/src/server/distributor-portal-data.js
+++ b/apps/web/src/server/distributor-portal-data.js
@@ -1,0 +1,88 @@
+// Finspeed Distributor Portal — dataset (Consolidated Pricing Matrix, 2024/25).
+// Server-only since WEB-039: dealer prices, margins, and portal records must
+// never be imported from client code — they are served exclusively through
+// /api/distributor/portal behind a session token, and a build-scan test
+// (distributor-boundary.test.mjs) fails if any of this re-enters a client chunk.
+// margin% is on retail: (retail - dp) / retail
+
+export const distributorPortalData = {
+  products: [
+    { id: 'red-snapper', model: 'Red Snapper', variant: '24" Non IBC', series: 'Urban', retail: 4800, dp: 3300, margin: 31.3, stock: 'in' },
+    { id: 'red-snapper', model: 'Red Snapper', variant: '26" IBC', series: 'Urban', retail: 5500, dp: 3400, margin: 38.2, stock: 'in' },
+    { id: 'sea-breeze', model: 'Sea Breeze', variant: '26" IBC', series: 'Urban', retail: 5500, dp: 3400, margin: 38.2, stock: 'in' },
+    { id: 'hammerhead', model: 'Hammerhead', variant: '24"', series: 'Street', retail: 6000, dp: 3900, margin: 35.0, stock: 'in' },
+    { id: 'great-white-shark', model: 'Great White Shark', variant: '26"', series: 'Street', retail: 6300, dp: 4000, margin: 36.5, stock: 'low' },
+    { id: 'tiger-shark', model: 'Tiger Shark', variant: '24"', series: 'Tiger', retail: 6500, dp: 4800, margin: 26.2, stock: 'in' },
+    { id: 'tiger-shark', model: 'Tiger Shark', variant: '26"', series: 'Tiger', retail: 7700, dp: 5500, margin: 28.6, stock: 'in' },
+    { id: 'lemon-shark', model: 'Lemon Shark', variant: '27.5"', series: 'Big Wheel', retail: 8700, dp: 5700, margin: 34.5, stock: 'in' },
+    { id: 'lightning-marlin', model: 'Lightning Marlin', variant: '700C', series: 'Hybrid', retail: 9500, dp: 7000, margin: 26.3, stock: 'low' },
+    { id: 'bull-shark', model: 'Bull Shark', variant: '29"', series: 'Big Wheel', retail: 9500, dp: 5900, margin: 37.9, stock: 'in' },
+    { id: 'shark-blue', model: 'Shark Blue', variant: '26" Geared', series: 'Geared Elite', retail: 9700, dp: 7000, margin: 27.8, stock: 'in' },
+    { id: 'mako-shark', model: 'Mako Shark', variant: '27.5" Geared', series: 'Geared Elite', retail: 10100, dp: 7300, margin: 27.7, stock: 'out' },
+    { id: 'sunset-marlin', model: 'Sunset Marlin', variant: '700C Geared', series: 'Hybrid', retail: 10500, dp: 7000, margin: 33.3, stock: 'in' },
+  ],
+  orders: [
+    { no: 'PO-2451', date: '12 Jun 2025', units: 60, value: 228000, status: 'Delivered' },
+    { no: 'PO-2460', date: '24 Jun 2025', units: 35, value: 171500, status: 'In transit' },
+    { no: 'PO-2477', date: '02 Jul 2025', units: 48, value: 262400, status: 'Processing' },
+    { no: 'PO-2489', date: '09 Jul 2025', units: 24, value: 141600, status: 'Processing' },
+  ],
+  // Credit / account terms for Ravi Stores (Tier 1)
+  account: {
+    legalName: 'Ravi Stores',
+    tradeName: 'Ravi Cycle Mart',
+    gstin: '09AABCR1234F1Z5',
+    pan: 'AABCR1234F',
+    contact: 'Ravi Kumar',
+    phone: '+91 98100 45678',
+    email: 'ravi@ravistores.in',
+    since: 'Mar 2019',
+    tier: 'Tier 1',
+    terms: 'Net 30',
+    creditLimit: 1500000,
+    creditUsed: 764400,
+    billing: { line1: 'Shop No. 14, Sector 18', line2: 'Noida, Uttar Pradesh 201301' },
+    shipping: { line1: 'Plot 7, Phase 2, Sector 63', line2: 'Noida, Uttar Pradesh 201307' },
+  },
+  team: [
+    { name: 'Ravi Kumar', role: 'Owner', email: 'ravi@ravistores.in', access: 'Full access', you: true },
+    { name: 'Anita Sharma', role: 'Purchasing', email: 'anita@ravistores.in', access: 'Orders & invoices' },
+    { name: 'Vikram Singh', role: 'Accounts', email: 'vikram@ravistores.in', access: 'Invoices only' },
+  ],
+  // Invoices (Net-30). paid = amount already settled.
+  invoices: [
+    { no: 'INV-8841', issued: '12 May 2025', due: '11 Jun 2025', po: 'PO-2451', amount: 228000, paid: 228000, status: 'Paid' },
+    { no: 'INV-8902', issued: '24 May 2025', due: '23 Jun 2025', po: 'PO-2460', amount: 171500, paid: 171500, status: 'Paid' },
+    { no: 'INV-8967', issued: '02 Jun 2025', due: '02 Jul 2025', po: 'PO-2477', amount: 262400, paid: 0, status: 'Overdue' },
+    { no: 'INV-9013', issued: '18 Jun 2025', due: '18 Jul 2025', po: 'PO-2489', amount: 141600, paid: 0, status: 'Due' },
+    { no: 'INV-9056', issued: '28 Jun 2025', due: '28 Jul 2025', po: 'PO-2494', amount: 98400, paid: 50000, status: 'Partial' },
+    { no: 'INV-9090', issued: '06 Jul 2025', due: '05 Aug 2025', po: 'PO-2501', amount: 312000, paid: 0, status: 'Due' },
+  ],
+  representative: {
+    name: 'Neha Verma',
+    title: 'Distributor Success Manager',
+    phone: '+91 99580 11234',
+    email: 'neha.verma@finspeed.in',
+    sla: 'Replies within 4 business hours',
+    hours: 'Mon–Sat · 9:30–18:30 IST',
+  },
+  tickets: [
+    { id: 'TK-3421', subject: 'Warranty claim — Mako Shark fork play', category: 'Warranty', status: 'In progress', updated: '2 days ago' },
+    { id: 'TK-3398', subject: 'Missing spares carton in PO-2477', category: 'Order issue', status: 'Resolved', updated: '6 days ago' },
+    { id: 'TK-3375', subject: 'GST invoice correction — INV-8902', category: 'Billing', status: 'Resolved', updated: '12 days ago' },
+  ],
+  faq: [
+    { q: 'Warranty & claims', a: 'Frames carry a 5-year structural warranty; components 12 months. Raise a Warranty ticket with the model, variant and serial — replacements dispatch ex-works within 5 working days of approval.' },
+    { q: 'Returns & replacements', a: 'Transit-damaged units are replaced free when reported within 48 hours of delivery with photos. Stock returns are accepted within 30 days at 90% of DP for unused, boxed units.' },
+    { q: 'Spares & accessories ordering', a: 'Spares ship against the same Net-30 terms as cycles. Use the Order builder for forks, wheelsets and drivetrain kits, or raise a Spares ticket for items not in the matrix.' },
+    { q: 'Payment terms & credit', a: 'Tier-1 accounts run on Net-30 from invoice date. Credit limits are reviewed quarterly against trailing volume — request an increase through your success manager.' },
+    { q: 'Dispatch & logistics', a: 'All orders dispatch ex-works Greater Noida. FTL freight is arranged on request and billed at actuals; LTL consignments are insured to destination.' },
+  ],
+  // richer order rows for the Orders screen (lines + ETA)
+  orderDetails: {
+    'PO-2451': { eta: 'Delivered 18 Jun', lines: [['bull-shark', '29"', 30], ['red-snapper', '24" Non IBC', 30]] },
+    'PO-2460': { eta: 'Arriving 28 Jun', lines: [['tiger-shark', '26"', 20], ['sea-breeze', '26" IBC', 15]] },
+    'PO-2477': { eta: 'Ships 27 Jun', lines: [['mako-shark', '27.5" Geared', 24], ['shark-blue', '26" Geared', 24]] },
+    'PO-2489': { eta: 'Ships 30 Jun', lines: [['lemon-shark', '27.5"', 12], ['lightning-marlin', '700C', 12]] },
+  },
+};

--- a/apps/web/src/server/distributor-session.js
+++ b/apps/web/src/server/distributor-session.js
@@ -1,0 +1,37 @@
+// Distributor portal session tokens (WEB-039).
+//
+// The sign-in remains an honest preview — credentials are not verified, so a
+// token is minted for any session request. This module is therefore a data
+// boundary and the single seam where real credential verification attaches
+// later, not access control. The secret is per-boot by design: portal sessions
+// are in-memory on the client and drop on reload, so tokens need not survive a
+// server restart; a request that straddles instances re-establishes its
+// session via the client's 401 retry.
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+const SECRET = randomBytes(32);
+const SESSION_TTL_MS = 4 * 60 * 60 * 1000;
+
+function sign(payload) {
+  return createHmac('sha256', SECRET).update(payload).digest('hex');
+}
+
+export function mintSessionToken(now = Date.now()) {
+  const expiresAt = now + SESSION_TTL_MS;
+  const payload = String(expiresAt);
+  return { token: `${payload}.${sign(payload)}`, expiresAt };
+}
+
+export function verifySessionToken(token, now = Date.now()) {
+  if (typeof token !== 'string') return false;
+  const separator = token.indexOf('.');
+  if (separator <= 0) return false;
+  const payload = token.slice(0, separator);
+  const signature = token.slice(separator + 1);
+  const expiresAt = Number(payload);
+  if (!Number.isFinite(expiresAt) || expiresAt <= now) return false;
+  const expected = Buffer.from(sign(payload), 'hex');
+  const provided = Buffer.from(signature, 'hex');
+  if (expected.length !== provided.length || provided.length === 0) return false;
+  return timingSafeEqual(expected, provided);
+}

--- a/apps/web/tests/distributor-access.spec.ts
+++ b/apps/web/tests/distributor-access.spec.ts
@@ -79,4 +79,48 @@ test.describe('distributor portal access', () => {
     await page.reload();
     await expect(page).toHaveURL(/\/distributor\/sign-in$/);
   });
+
+  test('the portal dataset endpoint refuses requests without a session', async ({ request }) => {
+    const bare = await request.get('/api/distributor/portal');
+    expect(bare.status()).toBe(401);
+    expect((await bare.json()).error).toContain('session');
+
+    const forged = await request.get('/api/distributor/portal', {
+      headers: { Authorization: 'Bearer 9999999999999.deadbeef' },
+    });
+    expect(forged.status()).toBe(401);
+  });
+
+  test('a minted session token unlocks the portal dataset', async ({ request }) => {
+    const session = await request.post('/api/distributor/session');
+    expect(session.status()).toBe(200);
+    expect(session.headers()['cache-control']).toContain('no-store');
+    const { token } = await session.json();
+    expect(typeof token).toBe('string');
+
+    const response = await request.get('/api/distributor/portal', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(response.status()).toBe(200);
+    expect(response.headers()['cache-control']).toContain('no-store');
+    const { portal } = await response.json();
+    expect(portal.products.some((row: { dp: number }) => row.dp === 3300)).toBe(true);
+    expect(portal.orderDetails['PO-2451']).toBeTruthy();
+  });
+
+  test('the portal has no client-side pricing fallback when the dataset API fails', async ({ page }) => {
+    await prepare(page);
+    await page.route('**/api/distributor/portal', (route) => route.abort());
+    await signIn(page);
+
+    await expect(page.getByText('The portal data could not be loaded.')).toBeVisible();
+    await expect(DEALER_PRICE_HEADER(page)).toHaveCount(0);
+    await expect(page.getByText('37.9%')).toHaveCount(0);
+
+    await page.unroute('**/api/distributor/portal');
+    await page.getByRole('button', { name: 'Try again' }).click();
+    await page.getByRole('button', { name: 'Price list' }).click();
+    await expect(DEALER_PRICE_HEADER(page)).toBeVisible();
+    await expect(page.getByText('37.9%')).toBeVisible();
+  });
 });

--- a/specs/contracts/web/json/spec.json
+++ b/specs/contracts/web/json/spec.json
@@ -933,6 +933,27 @@
         "specs/working-memory/**",
         "design-qa.md"
       ]
+    },
+    {
+      "id": "WEB-039",
+      "title": "Distributor pricing behind a server boundary",
+      "done_definition": [
+        "Dealer prices, margins, and portal records are absent from every client bundle chunk, enforced by an automated build-scan test",
+        "A session-token API gates the portal dataset; unauthenticated requests receive 401",
+        "The portal UX is unchanged for the honest preview flow, including sign-out and reload semantics",
+        "The proof states plainly that with unverified sign-in this is a data boundary and auth-ready seam, not access control",
+        "Full gate suite green; production verified after the merge deploys"
+      ],
+      "allow": [
+        "apps/web/**",
+        "specs/contracts/web/**",
+        "specs/notes/plans/web/WEB-039.md",
+        "specs/proofs/web/WEB-039/**",
+        "specs/notes/indexes/**",
+        "specs/project-progress/**",
+        "specs/working-memory/**",
+        "design-qa.md"
+      ]
     }
   ]
 }

--- a/specs/notes/plans/web/WEB-039.md
+++ b/specs/notes/plans/web/WEB-039.md
@@ -1,0 +1,65 @@
+# Plan — WEB-039
+
+- Context:
+  WEB-036 gated the distributor portal on an in-session sign-in but recorded a
+  standing follow-up: `distributor.js` — dealer prices, margins, orders,
+  account, invoices, tickets from the 2024/25 Consolidated Pricing Matrix —
+  was compiled into the public client bundle, so the gate was presentation,
+  not access control. The sign-in remains an honest preview by design
+  (credentials are not verified, stated in the UI), so no server route can
+  turn it into real authentication; what a server boundary can do is remove
+  the dataset from every served client chunk, put the only access path behind
+  an observable request boundary, and leave the single seam where real
+  credential verification attaches once dealer accounts exist. This slice does
+  exactly that and says exactly that.
+- Goals:
+  - Move the portal dataset to a server-only module served exclusively by
+    `GET /api/distributor/portal` behind a session token minted by
+    `POST /api/distributor/session` (preview semantics: minted for any caller,
+    HMAC-signed, per-boot secret, 4-hour expiry, 401 otherwise, no-store).
+  - Reduce the client `distributor.js` to presentation helpers; feed the seven
+    portal screens through a fetched `portal` prop with loading and honest
+    error states, a 401 re-session retry, and sign-out clearing the session.
+  - Enforce the boundary with an automated test that scans every built client
+    chunk for dataset sentinels, plus Playwright contracts for the 401, the
+    token flow, and the absence of any client-side pricing fallback.
+- Risks:
+  - The token gate is NOT access control while sign-in verifies nothing —
+    anyone can mint a session. The improvement is bundle removal, an
+    observable boundary, and auth readiness; the proof states this plainly.
+  - The per-boot secret invalidates tokens across server restarts or
+    instances; the client's expired-token retry re-establishes the session
+    transparently, matching the portal's in-memory session semantics.
+  - The portal now has a network dependency; a failed fetch shows an honest
+    error with retry instead of silently empty screens, covered by a
+    route-abort test.
+  - The apply form's GSTIN placeholder previously echoed the sample account's
+    exact GSTIN; it is generalized so no account-record string ships client-side.
+
+## Steps
+1. Server: `src/server/distributor-portal-data.js` (dataset),
+   `src/server/distributor-session.js` (HMAC session tokens), and the two API
+   routes with no-store semantics.
+2. Client: reduce `data/distributor.js` to helpers; add `portal-session.js`;
+   wire `DistributorApp` to open a session at sign-in, fetch the portal, and
+   pass it to Dashboard, PriceList, OrderBuilder, Orders, Invoices, Account,
+   and Support via alias-destructured props so screen bodies stay unchanged.
+3. Tests: `distributor-boundary.test.mjs` (client-module and built-chunk
+   sentinel scan) and three new distributor-access contracts (401, token
+   flow, no client fallback under API failure).
+4. Full gate suite, proof, telemetry, guarded close; verify in production
+   after the merge deploys (401 unauthenticated, served-chunk scan, signed-in
+   flow).
+
+## Execution Checklist
+- [x] Portal dataset absent from every built client chunk (automated scan).
+- [x] Session and portal APIs enforce the token contract with no-store.
+- [x] Portal UX unchanged for the preview flow; honest loading/error states;
+      sign-out and reload semantics intact.
+- [x] Full Playwright suite green including the three new contracts.
+- [ ] Production verified after deploy: 401 without a session, served chunks
+      clean, signed-in portal renders pricing.
+- [ ] Proof states the honest limit: data boundary and auth seam, not access
+      control, while sign-in stays unverified.
+- [ ] Telemetry refreshed.
+- [ ] Slice parked.

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -239,6 +239,12 @@
           "domain": "web",
           "title": "Per-route server titles, honest 404s, locator discoverability",
           "status": "done"
+        },
+        {
+          "id": "WEB-039",
+          "domain": "web",
+          "title": "Distributor pricing behind a server boundary",
+          "status": "active"
         }
       ]
     }

--- a/specs/proofs/web/WEB-039/README.md
+++ b/specs/proofs/web/WEB-039/README.md
@@ -1,0 +1,62 @@
+# WEB-039 Proof - Distributor pricing behind a server boundary
+
+## The honest limit, stated first
+
+The distributor sign-in remains an unverified preview (declared in the portal
+UI), so a session token is minted for any caller and **this slice is a data
+boundary and an auth-ready seam, not access control**. What changed is real
+nonetheless: dealer prices, margins, and portal records no longer exist in any
+served client chunk; the only path to them is an observable, no-store API
+behind a token; and `POST /api/distributor/session` is now the single place
+where genuine credential verification attaches once dealer accounts exist.
+
+## The boundary
+
+- `apps/web/src/server/distributor-portal-data.js` - the 2024/25 Consolidated
+  Pricing Matrix dataset, server-only.
+- `apps/web/src/server/distributor-session.js` - HMAC-SHA256 session tokens,
+  per-boot secret, 4-hour expiry, timing-safe verification. Per-boot is by
+  design: client sessions are in-memory and drop on reload, and the client
+  re-establishes a session transparently on 401.
+- `POST /api/distributor/session` and `GET /api/distributor/portal` - both
+  force-dynamic and `Cache-Control: no-store`; the portal route returns 401
+  without a valid bearer token.
+- `apps/web/src/design/data/distributor.js` - reduced to presentation helpers
+  (image path, INR formatting, tracking stages); the seven portal screens now
+  receive a fetched `portal` prop, alias-destructured so screen bodies are
+  unchanged. Loading and failure render honest states with retry; sign-out
+  clears the session; the apply form's GSTIN placeholder no longer echoes the
+  sample account's GSTIN.
+
+## Enforcement
+
+- `apps/web/src/design/data/distributor-boundary.test.mjs` - fails the unit
+  gate if the client module regains price fields, or if any built client chunk
+  under `.next/static` contains a dataset sentinel (PAN, invoice number,
+  ticket id, representative name, dealer-price pair). CI builds before unit
+  tests, so the chunk scan always runs there. It caught a real finding during
+  development: the apply form's placeholder GSTIN, now generalized.
+- `apps/web/tests/distributor-access.spec.ts` (+3): unauthenticated and
+  forged-token requests receive 401; a minted token unlocks the dataset with
+  no-store semantics; and with the portal API blocked, the signed-in UI shows
+  the honest failure state with no client-side pricing fallback, then recovers
+  through Try again once the API returns.
+
+## Parity evidence (recorded parity session, this workstation)
+
+- ESLint: 0 errors (37 pre-existing warnings, unchanged).
+- `tsc --noEmit`: clean.
+- Production build: clean; boundary chunk scan runs against its output.
+- Unit tests: **26/26** including both boundary contracts.
+- Full Playwright suite: **76/76** (5 original access contracts unchanged,
+  3 new boundary contracts).
+
+## Production verification
+
+Merging to protected `main` releases via Amplify. `production-check.mjs`
+(committed here, re-runnable) verifies the deployed behaviour: 401 without a
+session, token flow serving dealer rows, served-chunk sentinel scan, and the
+signed-in price list rendering API-served pricing. Its results land in
+`production-results.json` in the closing commit.
+
+final result: pending release — all local gates passed

--- a/specs/proofs/web/WEB-039/production-check.mjs
+++ b/specs/proofs/web/WEB-039/production-check.mjs
@@ -1,0 +1,75 @@
+// WEB-039 production verification driver.
+//
+// Run after the release reaches https://www.finspeed.online:
+//   cd apps/web && cp ../../specs/proofs/web/WEB-039/production-check.mjs ./pc-tmp.mjs && node ./pc-tmp.mjs && rm ./pc-tmp.mjs
+//
+// Checks:
+//   1. GET /api/distributor/portal without a session -> 401, no-store.
+//   2. POST /api/distributor/session -> token; portal fetch -> 200 with dealer rows.
+//   3. Every script chunk referenced by the served sign-in page is free of
+//      portal-data sentinels (the exhaustive scan is the build-time unit test;
+//      this confirms the deployed artefact).
+//   4. Signed-in browser flow renders dealer pricing from the API (screenshot).
+import { chromium } from '@playwright/test';
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BASE = process.env.CHECK_BASE || 'https://www.finspeed.online';
+const OUT = path.dirname(fileURLToPath(import.meta.url));
+const SENTINELS = ['AABCR1234F', 'INV-8967', 'TK-3421', 'Neha Verma'];
+const results = [];
+const record = (name, ok, detail = '') => {
+  results.push({ name, ok, detail: String(detail).slice(0, 200) });
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${detail ? ' — ' + String(detail).slice(0, 120) : ''}`);
+};
+
+// 1 + 2: API contract
+{
+  const bare = await fetch(`${BASE}/api/distributor/portal`);
+  record('unauthenticated portal request returns 401', bare.status === 401, `status=${bare.status}`);
+  record('401 response is no-store', (bare.headers.get('cache-control') || '').includes('no-store'));
+
+  const session = await fetch(`${BASE}/api/distributor/session`, { method: 'POST' });
+  const { token } = await session.json();
+  record('session endpoint mints a token', session.status === 200 && typeof token === 'string');
+
+  const portal = await fetch(`${BASE}/api/distributor/portal`, { headers: { Authorization: `Bearer ${token}` } });
+  const payload = portal.status === 200 ? await portal.json() : null;
+  record('token unlocks the portal dataset', Boolean(payload?.portal?.products?.some((row) => row.dp === 3300)), `status=${portal.status}`);
+}
+
+// 3: served chunks
+{
+  const html = await (await fetch(`${BASE}/distributor/sign-in`)).text();
+  const scripts = [...new Set([...html.matchAll(/src="(\/_next\/static\/[^"]+\.js)"/g)].map((m) => m[1]))];
+  record('sign-in page references script chunks', scripts.length > 0, `count=${scripts.length}`);
+  let dirty = [];
+  for (const src of scripts) {
+    const body = await (await fetch(`${BASE}${src}`)).text();
+    for (const sentinel of SENTINELS) if (body.includes(sentinel)) dirty.push(`${src}:${sentinel}`);
+  }
+  record('served chunks are free of portal-data sentinels', dirty.length === 0, dirty.join(', '));
+}
+
+// 4: signed-in flow
+{
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  await page.addInitScript(() => window.localStorage.setItem('finspeed-consent', 'denied'));
+  await page.goto(`${BASE}/distributor/sign-in`, { waitUntil: 'networkidle', timeout: 45000 });
+  await page.getByLabel('Dealer ID or email').fill('ravi@ravistores.in');
+  await page.getByLabel('Password').fill('preview');
+  await page.getByRole('button', { name: 'Enter portal' }).click();
+  await page.getByRole('button', { name: 'Price list' }).click();
+  const priceVisible = await page.locator('th', { hasText: 'Distributor price' }).isVisible({ timeout: 20000 }).catch(() => false);
+  const marginVisible = await page.getByText('37.9%').first().isVisible({ timeout: 10000 }).catch(() => false);
+  record('signed-in price list renders API-served dealer pricing', priceVisible && marginVisible);
+  await page.screenshot({ path: path.join(OUT, 'production-price-list.png') });
+  await browser.close();
+}
+
+writeFileSync(path.join(OUT, 'production-results.json'), JSON.stringify({ base: BASE, when: new Date().toISOString(), results }, null, 2) + '\n');
+const failed = results.filter((r) => !r.ok);
+console.log(`\nRESULT: ${failed.length === 0 ? 'PASS' : 'FAIL'} — ${results.length - failed.length}/${results.length} pass`);
+process.exit(failed.length === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

**WEB-039** — closes WEB-036's standing follow-up: `distributor.js` (dealer prices, margins, orders, invoices from the 2024/25 Consolidated Pricing Matrix) was compiled into the public client bundle, making the portal gate presentation rather than a data boundary.

- Dataset moved to a server-only module, served exclusively by `GET /api/distributor/portal` behind an HMAC session token from `POST /api/distributor/session` (force-dynamic, no-store, 401 without a valid bearer; per-boot secret with transparent client re-session on 401).
- **Honest limit, stated in code, proof, and here:** sign-in remains an unverified preview, so a token is minted for any caller — this is bundle removal plus an observable boundary plus the single seam where real credential verification attaches later, **not access control**.
- Client `distributor.js` reduced to presentation helpers; the seven portal screens take a fetched `portal` prop (alias-destructured — screen bodies unchanged); honest loading/error states with retry; sign-out clears the session; apply-form GSTIN placeholder generalized so no account string ships client-side.
- **Enforcement:** a build-scan unit test fails if any client chunk regains a dataset sentinel (it already caught the placeholder echo during development), plus three new Playwright contracts (401/forged token, token flow with no-store, no client-side pricing fallback under API failure).

## Gates

ESLint 0 errors · tsc clean · unit **26/26** (incl. chunk scan) · Playwright **76/76** · production build clean.

Merging deploys via Amplify; `specs/proofs/web/WEB-039/production-check.mjs` verifies the released behaviour (401, token flow, served-chunk scan, signed-in pricing) and its results close the slice in a follow-up PR, per the WEB-038 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)