### PR TITLE
feat(web): WEB-040 verify an invitation passphrase at the distributor session seam

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
         reuseExistingServer: !process.env.CI,
         timeout: 180 * 1000,
         stdout: 'pipe',
-        stderr: 'pipe'
+        stderr: 'pipe',
+        env: {
+          ...process.env,
+          // Dev/CI invitation passphrase is the well-known word "preview"
+          // (WEB-040). Production uses a steward-set secret; this hash never
+          // gates anything real.
+          DISTRIBUTOR_ACCESS_HASH:
+            'scrypt$16384$8$1$Zmluc3BlZWQtZGV2LXByZQ$x65US9uga_xLKxytyfAhVT_i7ZPVkOBp6J1KVhkoiGY'
+        }
       }
 });

--- a/apps/web/src/app/api/distributor/session/route.ts
+++ b/apps/web/src/app/api/distributor/session/route.ts
@@ -1,17 +1,40 @@
 import { NextResponse } from 'next/server';
 import { mintSessionToken } from '@/server/distributor-session';
+import { verifyAccessPassphrase } from '@/server/distributor-access';
 
 export const dynamic = 'force-dynamic';
 
-// Preview semantics, stated in the portal UI: credentials are not verified and
-// no live dealer account is opened, so a session is granted to any caller.
-// This handler is the single seam where real credential verification attaches
-// once dealer accounts exist; until then the token only moves the dataset off
-// the client bundle and behind an observable request boundary.
-export async function POST() {
+const NO_STORE = { 'Cache-Control': 'no-store' } as const;
+
+// WEB-040: sessions are granted only against the steward-managed invitation
+// passphrase. Dealer IDs remain unlinked to accounts — per-dealer credential
+// verification attaches here once dealer accounts exist as a business fact.
+// Fail-closed: a deployment without DISTRIBUTOR_ACCESS_HASH refuses access.
+export async function POST(request: Request) {
+  let passphrase = '';
+  try {
+    const body = await request.json();
+    passphrase = typeof body?.passphrase === 'string' ? body.passphrase : '';
+  } catch {
+    passphrase = '';
+  }
+
+  const result = verifyAccessPassphrase(passphrase);
+  if (!result.configured) {
+    return NextResponse.json(
+      { error: 'Distributor access is not configured on this deployment.' },
+      { status: 503, headers: NO_STORE },
+    );
+  }
+  if (!result.ok) {
+    // Constant small delay blunts online guessing without an external store;
+    // per-instance only — recorded as an accepted limitation in the proof.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return NextResponse.json(
+      { error: 'That access passphrase was not recognised.' },
+      { status: 401, headers: NO_STORE },
+    );
+  }
   const { token, expiresAt } = mintSessionToken();
-  return NextResponse.json(
-    { token, expiresAt },
-    { headers: { 'Cache-Control': 'no-store' } },
-  );
+  return NextResponse.json({ token, expiresAt }, { headers: NO_STORE });
 }

--- a/apps/web/src/design/data/distributor-access.test.mjs
+++ b/apps/web/src/design/data/distributor-access.test.mjs
@@ -1,0 +1,43 @@
+// WEB-040 invited-access verification contract.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { randomBytes, scryptSync } from 'node:crypto';
+
+import { accessConfiguration, verifyAccessPassphrase } from '../../server/distributor-access.js';
+
+function hashFor(passphrase, { N = 16384, r = 8, p = 1 } = {}) {
+  const salt = randomBytes(16);
+  const hash = scryptSync(passphrase, salt, 32, { N, r, p });
+  return `scrypt$${N}$${r}$${p}$${salt.toString('base64url')}$${hash.toString('base64url')}`;
+}
+
+test('an unconfigured environment fails closed', () => {
+  const result = verifyAccessPassphrase('anything', {});
+  assert.equal(result.ok, false);
+  assert.equal(result.configured, false);
+});
+
+test('malformed configuration is treated as unconfigured, never as open', () => {
+  for (const bad of ['plaintext', 'scrypt$0$8$1$AAAA$BBBB', 'scrypt$16384$8$1$short$short', 'bcrypt$x$y$z$w']) {
+    const result = verifyAccessPassphrase('anything', { DISTRIBUTOR_ACCESS_HASH: bad });
+    assert.equal(result.ok, false, bad);
+    assert.equal(result.configured, false, bad);
+    assert.equal(accessConfiguration({ DISTRIBUTOR_ACCESS_HASH: bad }).configured, false, bad);
+  }
+});
+
+test('the correct passphrase verifies and wrong ones are rejected', () => {
+  const env = { DISTRIBUTOR_ACCESS_HASH: hashFor('correct horse battery staple') };
+  assert.deepEqual(verifyAccessPassphrase('correct horse battery staple', env), { ok: true, configured: true });
+  for (const wrong of ['wrong', '', 'correct horse battery stapl', 'CORRECT HORSE BATTERY STAPLE', 'a'.repeat(300)]) {
+    const result = verifyAccessPassphrase(wrong, env);
+    assert.equal(result.ok, false, JSON.stringify(wrong.slice(0, 20)));
+    assert.equal(result.configured, true);
+  }
+});
+
+test('the committed dev hash verifies exactly the well-known preview passphrase', () => {
+  const env = { DISTRIBUTOR_ACCESS_HASH: 'scrypt$16384$8$1$Zmluc3BlZWQtZGV2LXByZQ$x65US9uga_xLKxytyfAhVT_i7ZPVkOBp6J1KVhkoiGY' };
+  assert.equal(verifyAccessPassphrase('preview', env).ok, true);
+  assert.equal(verifyAccessPassphrase('Preview', env).ok, false);
+});

--- a/apps/web/src/design/features/distributor/Auth.jsx
+++ b/apps/web/src/design/features/distributor/Auth.jsx
@@ -6,10 +6,22 @@ import { useLucideIcons } from '../../lib/useLucideIcons.js';
 function DistAuth({ onEnter }) {
   const [mode, setMode] = React.useState('signin'); // 'signin' | 'apply'
   const [submitted, setSubmitted] = React.useState(false);
+  const [passphrase, setPassphrase] = React.useState('');
+  const [error, setError] = React.useState(null);
+  const [pending, setPending] = React.useState(false);
   const [ref] = React.useState(()=> 'APP-' + Math.floor(10000 + Math.random()*90000));
   useLucideIcons();
 
-  function submit(e){ e.preventDefault(); onEnter && onEnter(); }
+  async function submit(e){
+    e.preventDefault();
+    if (pending || !onEnter) return;
+    setPending(true); setError(null);
+    const result = await onEnter(passphrase);
+    if (!result || !result.ok) {
+      setError((result && result.error) || 'Sign-in failed. Try again.');
+      setPending(false);
+    }
+  }
   function apply(e){ e.preventDefault(); setSubmitted(true); }
 
   const stat = (n,l) => (
@@ -80,7 +92,12 @@ function DistAuth({ onEnter }) {
               <p style={{ font:'var(--text-body-sm)', color:'var(--text-muted)', margin:'0 0 var(--space-6)' }}>Access pricing, order builder and invoices.</p>
               <form onSubmit={submit} style={{ display:'flex', flexDirection:'column', gap:'var(--space-4)' }}>
                 <Input label="Dealer ID or email" placeholder="ravi@ravistores.in" autoComplete="username" required iconLeft={<i data-lucide="building-2" style={{width:17,height:17}}></i>} />
-                <Input label="Password" type="password" placeholder="••••••••" autoComplete="current-password" required iconLeft={<i data-lucide="lock" style={{width:17,height:17}}></i>} />
+                <Input label="Access passphrase" type="password" placeholder="••••••••" autoComplete="current-password" required value={passphrase} onChange={(e)=>setPassphrase(e.target.value)} iconLeft={<i data-lucide="lock" style={{width:17,height:17}}></i>} />
+                {error ? (
+                  <p role="alert" style={{ display:'flex', gap:8, alignItems:'flex-start', font:'var(--fw-medium) var(--fs-sm)/1.4 var(--font-body)', color:'var(--danger, #b3261e)', margin:0 }}>
+                    <i data-lucide="alert-circle" style={{ width:16, height:16, marginTop:1, flex:'none' }}></i>{error}
+                  </p>
+                ) : null}
                 <div className="dist-auth-options" style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginTop:'calc(-1 * var(--space-1))' }}>
                   <label style={{ display:'flex', alignItems:'center', gap:8, cursor:'pointer', font:'var(--fw-regular) var(--fs-sm)/1 var(--font-body)', color:'var(--text-body)' }}>
                     <input type="checkbox" defaultChecked style={{ accentColor:'var(--brand)', width:16, height:16 }} /> Keep me signed in
@@ -88,12 +105,12 @@ function DistAuth({ onEnter }) {
                   <button type="button" style={{ background:'none', border:'none', padding:0, cursor:'pointer', font:'var(--fw-semibold) var(--fs-sm)/1 var(--font-body)', color:'var(--brand-ink)' }}>Forgot password?</button>
                 </div>
                 <div style={{ marginTop:'var(--space-2)' }}>
-                  <Button type="submit" variant="primary" size="lg" full iconRight={<i data-lucide="arrow-right" style={{width:18,height:18}}></i>}>Enter portal</Button>
+                  <Button type="submit" variant="primary" size="lg" full disabled={pending} iconRight={<i data-lucide="arrow-right" style={{width:18,height:18}}></i>}>{pending ? 'Checking…' : 'Enter portal'}</Button>
                 </div>
               </form>
               <p style={{ display:'flex', gap:8, alignItems:'flex-start', font:'var(--fw-regular) var(--fs-xs)/1.5 var(--font-body)', color:'var(--text-faint)', margin:'var(--space-4) 0 0' }}>
                 <i data-lucide="info" style={{ width:15, height:15, marginTop:2, flex:'none' }}></i>
-                Preview only. Credentials are not verified and no live dealer account is opened. The portal shows sample pricing and orders that stay in this browser.
+                Access is limited to invited partners and the passphrase is verified. Dealer IDs are not yet linked to individual accounts, and the portal shows sample pricing and orders that stay in this browser.
               </p>
             </React.Fragment>
           ) : (

--- a/apps/web/src/design/features/distributor/DistributorApp.jsx
+++ b/apps/web/src/design/features/distributor/DistributorApp.jsx
@@ -64,22 +64,39 @@ export default function DistributorApp() {
   const [portal, setPortal] = React.useState(null);
   const [portalError, setPortalError] = React.useState(null);
   const sessionToken = React.useRef(null);
+  // Kept in memory for transparent re-session on token expiry; dropped on
+  // reload and sign-out along with everything else, by design.
+  const passphraseRef = React.useRef(null);
 
   const loadPortal = React.useCallback(async () => {
     setPortalError(null);
     try {
-      if (!sessionToken.current) sessionToken.current = await openPortalSession();
+      if (!sessionToken.current) sessionToken.current = await openPortalSession(passphraseRef.current);
       try {
         setPortal(await fetchPortal(sessionToken.current));
       } catch (error) {
         if (!error.expired) throw error;
-        sessionToken.current = await openPortalSession();
+        sessionToken.current = await openPortalSession(passphraseRef.current);
         setPortal(await fetchPortal(sessionToken.current));
       }
     } catch {
       setPortalError('The portal data could not be loaded.');
     }
   }, []);
+
+  async function enterPortal(passphrase) {
+    try {
+      const token = await openPortalSession(passphrase);
+      passphraseRef.current = passphrase;
+      sessionToken.current = token;
+      setAuthenticated(true);
+      navigate('/distributor');
+      loadPortal();
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error.message || 'Sign-in failed. Try again.' };
+    }
+  }
   const atSignIn = normalizedPath === '/distributor/sign-in';
   const signedOut = !authenticated;
 
@@ -178,7 +195,7 @@ export default function DistributorApp() {
 
   if (signedOut) {
     if (!atSignIn) return <Navigate to="/distributor/sign-in" replace />;
-    return <Auth onEnter={() => { setAuthenticated(true); loadPortal(); navigate('/distributor'); }} />;
+    return <Auth onEnter={enterPortal} />;
   }
 
   if (atSignIn) return <Navigate to="/distributor" replace />;
@@ -207,7 +224,7 @@ export default function DistributorApp() {
 
   return (
     <div className="dist-app-shell" style={{ display: 'flex', minHeight: '100vh', background: 'var(--bg-page)' }}>
-      <Sidebar route={route} onNav={setRoute} orderCount={orderCount} onSignOut={() => { setAuthenticated(false); setPortal(null); setPortalError(null); sessionToken.current = null; navigate('/distributor/sign-in'); }} />
+      <Sidebar route={route} onNav={setRoute} orderCount={orderCount} onSignOut={() => { setAuthenticated(false); setPortal(null); setPortalError(null); sessionToken.current = null; passphraseRef.current = null; navigate('/distributor/sign-in'); }} />
       <div className="dist-main" style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
         <Topbar title={title} subtitle={subtitle} query={query} onSearch={setQuery} />
         <div className="dist-route-body" style={{ flex: 1, minWidth: 0 }}>

--- a/apps/web/src/design/features/distributor/portal-session.js
+++ b/apps/web/src/design/features/distributor/portal-session.js
@@ -3,9 +3,18 @@
 // portal obtains dealer pricing. Sessions are in-memory by design — a reload
 // returns to sign-in, matching the portal's honest preview semantics.
 
-export async function openPortalSession() {
-  const response = await fetch('/api/distributor/session', { method: 'POST' });
-  if (!response.ok) throw new Error(`session request failed (${response.status})`);
+export async function openPortalSession(passphrase) {
+  const response = await fetch('/api/distributor/session', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ passphrase }),
+  });
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({}));
+    const error = new Error(detail.error || `session request failed (${response.status})`);
+    error.status = response.status;
+    throw error;
+  }
   const { token } = await response.json();
   if (!token) throw new Error('session response carried no token');
   return token;

--- a/apps/web/src/server/distributor-access.js
+++ b/apps/web/src/server/distributor-access.js
@@ -1,0 +1,41 @@
+// Invited-access verification for the distributor portal (WEB-040).
+//
+// The steward sets DISTRIBUTOR_ACCESS_HASH (format: scrypt$N$r$p$salt$hash,
+// base64url salt and hash) via scripts/set-distributor-access.mjs. Dealer IDs
+// are not yet account-linked — this verifies one invitation passphrase, which
+// is the honest step available while dealer accounts do not exist as a
+// business fact. Fail-closed by design: an unconfigured deployment refuses
+// access rather than silently opening the preview.
+import { scryptSync, timingSafeEqual } from 'node:crypto';
+
+const ENV_KEY = 'DISTRIBUTOR_ACCESS_HASH';
+
+export function accessConfiguration(env = process.env) {
+  const raw = env[ENV_KEY];
+  if (!raw) return { configured: false };
+  const parts = raw.split('$');
+  if (parts.length !== 6 || parts[0] !== 'scrypt') return { configured: false, malformed: true };
+  const [, nStr, rStr, pStr] = parts;
+  const N = Number(nStr); const r = Number(rStr); const p = Number(pStr);
+  if (![N, r, p].every((v) => Number.isInteger(v) && v > 0)) return { configured: false, malformed: true };
+  try {
+    const salt = Buffer.from(parts[4], 'base64url');
+    const hash = Buffer.from(parts[5], 'base64url');
+    if (salt.length < 16 || hash.length < 32) return { configured: false, malformed: true };
+    return { configured: true, N, r, p, salt, hash };
+  } catch {
+    return { configured: false, malformed: true };
+  }
+}
+
+export function verifyAccessPassphrase(passphrase, env = process.env) {
+  const config = accessConfiguration(env);
+  if (!config.configured) return { ok: false, configured: false };
+  if (typeof passphrase !== 'string' || passphrase.length === 0 || passphrase.length > 256) {
+    return { ok: false, configured: true };
+  }
+  const derived = scryptSync(passphrase, config.salt, config.hash.length, {
+    N: config.N, r: config.r, p: config.p,
+  });
+  return { ok: timingSafeEqual(derived, config.hash), configured: true };
+}

--- a/apps/web/tests/distributor-access.spec.ts
+++ b/apps/web/tests/distributor-access.spec.ts
@@ -23,9 +23,10 @@ async function prepare(page: Page) {
 async function signIn(page: Page) {
   await page.goto('/distributor/sign-in');
   await page.getByLabel('Dealer ID or email').fill('ravi@ravistores.in');
-  await page.getByLabel('Password').fill('preview');
+  await page.getByLabel('Access passphrase').fill('preview');
   await page.getByRole('button', { name: 'Enter portal' }).click();
-  await expect(page).toHaveURL(/\/distributor$/);
+  // First hit compiles the session API route in dev; allow for the cold start.
+  await expect(page).toHaveURL(/\/distributor$/, { timeout: 20_000 });
 }
 
 test.describe('distributor portal access', () => {
@@ -47,13 +48,18 @@ test.describe('distributor portal access', () => {
     await expect(page.getByText(/Avg distributor margin/)).toHaveCount(0);
   });
 
-  test('the sign-in screen states that credentials are not verified', async ({ page }) => {
+  test('the sign-in screen states the invited-access truth with no prefilled values', async ({ page }) => {
     await prepare(page);
     await page.goto('/distributor/sign-in');
 
-    await expect(page.getByText(/Preview only\. Credentials are not verified/i)).toBeVisible();
+    // WEB-040 contract change: the passphrase IS verified now, so the old
+    // "credentials are not verified" statement would be false. The notice
+    // keeps the remaining honest limits: invitation access, unlinked dealer
+    // IDs, sample data.
+    await expect(page.getByText(/Access is limited to invited partners and the passphrase is verified/i)).toBeVisible();
+    await expect(page.getByText(/Dealer IDs are not yet linked to individual accounts/i)).toBeVisible();
     await expect(page.getByLabel('Dealer ID or email')).toHaveValue('');
-    await expect(page.getByLabel('Password')).toHaveValue('');
+    await expect(page.getByLabel('Access passphrase')).toHaveValue('');
   });
 
   test('signing in opens the portal and signing out closes it again', async ({ page }) => {
@@ -92,7 +98,7 @@ test.describe('distributor portal access', () => {
   });
 
   test('a minted session token unlocks the portal dataset', async ({ request }) => {
-    const session = await request.post('/api/distributor/session');
+    const session = await request.post('/api/distributor/session', { data: { passphrase: 'preview' } });
     expect(session.status()).toBe(200);
     expect(session.headers()['cache-control']).toContain('no-store');
     const { token } = await session.json();
@@ -106,6 +112,23 @@ test.describe('distributor portal access', () => {
     const { portal } = await response.json();
     expect(portal.products.some((row: { dp: number }) => row.dp === 3300)).toBe(true);
     expect(portal.orderDetails['PO-2451']).toBeTruthy();
+  });
+
+  test('a wrong passphrase is rejected with an inline error and no session', async ({ page, request }) => {
+    const denied = await request.post('/api/distributor/session', { data: { passphrase: 'wrong-passphrase' } });
+    expect(denied.status()).toBe(401);
+    const bodiless = await request.post('/api/distributor/session');
+    expect(bodiless.status()).toBe(401);
+
+    await prepare(page);
+    await page.goto('/distributor/sign-in');
+    await page.getByLabel('Dealer ID or email').fill('ravi@ravistores.in');
+    await page.getByLabel('Access passphrase').fill('wrong-passphrase');
+    await page.getByRole('button', { name: 'Enter portal' }).click();
+
+    await expect(page.getByRole('alert').filter({ hasText: 'not recognised' })).toBeVisible({ timeout: 20_000 });
+    await expect(page).toHaveURL(/\/distributor\/sign-in$/);
+    await expect(DEALER_PRICE_HEADER(page)).toHaveCount(0);
   });
 
   test('the portal has no client-side pricing fallback when the dataset API fails', async ({ page }) => {

--- a/scripts/set-distributor-access.mjs
+++ b/scripts/set-distributor-access.mjs
@@ -1,0 +1,63 @@
+// Steward tool: set the distributor portal access passphrase (WEB-040).
+//
+// Run this yourself — the passphrase is read from your terminal, hashed with
+// scrypt, and only the hash leaves this process. Plaintext is never printed,
+// logged, or sent anywhere.
+//
+//   node scripts/set-distributor-access.mjs            # print the hash + instructions
+//   node scripts/set-distributor-access.mjs --apply    # merge-set it on the Amplify app via AWS CLI
+//
+// --apply requires an authenticated AWS CLI (`aws login`, per the release
+// runbook) and MERGES the variable into the app's existing environment map —
+// it fetches current variables first and never replaces or prints them.
+import { randomBytes, scryptSync } from 'node:crypto';
+import { createInterface } from 'node:readline';
+import { execFileSync } from 'node:child_process';
+
+const APP_ID = 'd2h8tz7elv2xy8';
+const REGION = 'ap-south-1';
+const ENV_KEY = 'DISTRIBUTOR_ACCESS_HASH';
+const [N, r, p] = [16384, 8, 1];
+
+function ask(question, { hidden } = {}) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  if (hidden) {
+    rl._writeToOutput = (s) => { if (s.includes(question)) rl.output.write(question); };
+  }
+  return new Promise((resolve) => rl.question(question, (answer) => { rl.close(); if (hidden) process.stdout.write('\n'); resolve(answer); }));
+}
+
+const passphrase = await ask('New access passphrase (min 12 chars, input hidden): ', { hidden: true });
+if (!passphrase || passphrase.length < 12) {
+  console.error('Refusing: passphrase must be at least 12 characters.');
+  process.exit(1);
+}
+const confirm = await ask('Repeat it: ', { hidden: true });
+if (confirm !== passphrase) {
+  console.error('Refusing: passphrases did not match.');
+  process.exit(1);
+}
+
+const salt = randomBytes(16);
+const hash = scryptSync(passphrase, salt, 32, { N, r, p });
+const value = `scrypt$${N}$${r}$${p}$${salt.toString('base64url')}$${hash.toString('base64url')}`;
+
+if (!process.argv.includes('--apply')) {
+  console.log('\nHash value (safe to store as an environment variable):\n');
+  console.log(`${ENV_KEY}=${value}`);
+  console.log('\nSet it on the Amplify app (merge — do not replace the existing map):');
+  console.log(`  node scripts/set-distributor-access.mjs --apply`);
+  console.log('or in the Amplify console: App settings -> Environment variables.');
+  console.log('A new build is required for the runtime to pick it up (Amplify -> Redeploy this version).');
+  process.exit(0);
+}
+
+console.log('\nFetching current Amplify environment variable KEYS (values are never printed)…');
+const app = JSON.parse(execFileSync('aws', ['amplify', 'get-app', '--app-id', APP_ID, '--region', REGION], { encoding: 'utf8' }));
+const current = app.app.environmentVariables || {};
+console.log('existing keys:', Object.keys(current).join(', ') || '(none)');
+const merged = { ...current, [ENV_KEY]: value };
+const args = ['amplify', 'update-app', '--app-id', APP_ID, '--region', REGION, '--environment-variables'];
+const kv = Object.entries(merged).map(([k, v]) => `${k}=${v}`).join(',');
+execFileSync('aws', [...args, kv], { stdio: ['ignore', 'ignore', 'inherit'] });
+console.log(`${ENV_KEY} merged onto app ${APP_ID}. Trigger a redeploy so the runtime picks it up.`);

--- a/specs/contracts/web/json/spec.json
+++ b/specs/contracts/web/json/spec.json
@@ -954,6 +954,28 @@
         "specs/working-memory/**",
         "design-qa.md"
       ]
+    },
+    {
+      "id": "WEB-040",
+      "title": "Invited-access verification for the distributor portal",
+      "done_definition": [
+        "The session seam verifies a steward-managed access passphrase (scrypt, timing-safe); wrong passphrases are rejected with an inline error",
+        "An unconfigured deployment fails closed with an honest not-configured state, never silently open",
+        "The steward sets the secret with a merge-safe script that never exposes plaintext or existing env values",
+        "Portal copy states the new truth: access by invitation, sample data, dealer IDs not yet account-linked",
+        "Full gates green; production verified in both the unconfigured and configured states"
+      ],
+      "allow": [
+        "apps/web/**",
+        "scripts/**",
+        "specs/contracts/web/**",
+        "specs/notes/plans/web/WEB-040.md",
+        "specs/proofs/web/WEB-040/**",
+        "specs/notes/indexes/**",
+        "specs/project-progress/**",
+        "specs/working-memory/**",
+        "design-qa.md"
+      ]
     }
   ]
 }

--- a/specs/notes/plans/web/WEB-040.md
+++ b/specs/notes/plans/web/WEB-040.md
@@ -1,0 +1,65 @@
+# Plan — WEB-040
+
+- Context:
+  WEB-039 moved dealer pricing behind a server boundary but recorded the honest
+  limit: sign-in verified nothing, so anyone could mint a session. Real
+  per-dealer authentication remains blocked on a business fact — dealer
+  accounts do not exist, and the portal's records are declared sample data.
+  The steward chose the honest intermediate step: one invitation passphrase,
+  managed by the steward, verified server-side at the WEB-039 session seam.
+  Access becomes real (wrong passphrases are rejected); the portal remains a
+  sample-data preview and says so; per-dealer accounts attach at the same seam
+  later without changing the session contract.
+- Goals:
+  - Verify an scrypt-hashed passphrase (from `DISTRIBUTOR_ACCESS_HASH`) at
+    `POST /api/distributor/session`; reject with an inline sign-in error;
+    fail closed with an honest 503 when the deployment is unconfigured.
+  - Keep the passphrase's plaintext out of the repository, the logs, and the
+    assistant's hands: the steward sets it with a merge-safe script that
+    fetches and preserves the app's existing environment variables.
+  - Update the sign-in copy to the new truth (invited access, verified
+    passphrase, unlinked dealer IDs, sample data) and the contract tests with
+    it — a deliberate change to the WEB-036 "credentials are not verified"
+    statement, which this slice makes false.
+- Risks:
+  - Merging deploys before the production secret exists: the portal shows the
+    honest not-configured state until the steward runs the script and
+    redeploys. Accepted deliberately over any silently-open fallback.
+  - `aws amplify update-app --environment-variables` replaces the whole map;
+    the steward script fetches and merges, and prints keys only, because the
+    app already carries sensitive variables (WEB-022).
+  - The failure delay is per-instance memory only — online guessing is
+    blunted, not rate-limited across instances; recorded as an accepted
+    limitation pending real accounts.
+  - The dev/CI passphrase ("preview") and its hash are deliberately public;
+    they gate nothing outside local and CI web servers.
+
+## Steps
+1. `src/server/distributor-access.js`: parse/validate the hash format,
+   scrypt + timing-safe verification, fail-closed on missing or malformed
+   configuration.
+2. Session route: verify passphrase from the JSON body; 503 unconfigured,
+   401 wrong (with delay), token on success. Client: passphrase-carrying
+   sign-in with pending state and inline rejection; in-memory passphrase for
+   transparent re-session; sign-out clears everything.
+3. `scripts/set-distributor-access.mjs`: steward-run, hidden input, length
+   floor, fresh salt, merge-safe `--apply`, plaintext never printed.
+4. Tests: four unit contracts for the verifier; Playwright web server carries
+   the dev hash; contracts updated for the new notice and label; new
+   wrong-passphrase rejection test (API and UI).
+5. Gates, proof, guarded close; two-state production verification (honest
+   503 before the secret, real accept/reject after the steward sets it).
+
+## Execution Checklist
+- [x] Verifier fails closed (missing and malformed) and verifies correctly;
+      unit contracts green.
+- [x] Session route enforces 503/401/token; sign-in rejects inline; full
+      Playwright suite green with the updated contracts.
+- [x] Steward script is merge-safe and never exposes plaintext or existing
+      values.
+- [x] Sign-in copy states the new truth; WEB-036 contract change recorded.
+- [ ] Production verified unconfigured (honest 503 state) after merge.
+- [ ] Production verified configured after the steward sets the secret:
+      wrong passphrase rejected; steward confirms the real passphrase enters.
+- [ ] Telemetry refreshed.
+- [ ] Slice parked.

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -245,6 +245,12 @@
           "domain": "web",
           "title": "Distributor pricing behind a server boundary",
           "status": "done"
+        },
+        {
+          "id": "WEB-040",
+          "domain": "web",
+          "title": "Invited-access verification for the distributor portal",
+          "status": "active"
         }
       ]
     }

--- a/specs/proofs/web/WEB-040/README.md
+++ b/specs/proofs/web/WEB-040/README.md
@@ -1,0 +1,58 @@
+# WEB-040 Proof - Invited-access verification for the distributor portal
+
+## What this is, and is not
+
+The WEB-039 session seam now verifies a steward-managed invitation passphrase:
+wrong passphrases are genuinely rejected, server-side, with scrypt and
+timing-safe comparison. It is **one shared invitation secret, not per-dealer
+accounts** — dealer accounts still do not exist as a business fact, dealer IDs
+remain unlinked, and the portal still shows sample data and says so. The
+sign-in notice states the new truth, deliberately replacing the WEB-036
+"credentials are not verified" statement that this slice makes false.
+
+## The mechanism
+
+- `DISTRIBUTOR_ACCESS_HASH` env var: `scrypt$N$r$p$salt$hash` (base64url).
+  Missing or malformed configuration **fails closed**: the session endpoint
+  answers 503 with an honest not-configured error — never silently open.
+- `POST /api/distributor/session` verifies the JSON-body passphrase: 401 with
+  a 300ms delay on mismatch (per-instance guessing blunt — an accepted
+  limitation recorded in the plan), token on success, no-store throughout.
+- The client carries the passphrase from the sign-in form (controlled field,
+  pending state, inline `role=alert` rejection) and keeps it in memory only,
+  for transparent re-session on token expiry; sign-out and reload drop it.
+- `scripts/set-distributor-access.mjs` (steward-run): hidden input, 12-char
+  floor, fresh 16-byte salt, plaintext never printed or transmitted;
+  `--apply` **fetches and merges** the Amplify app's existing environment
+  variables (keys logged, values never) because `update-app` replaces the map
+  and the app already carries sensitive variables (WEB-022).
+- Dev/CI use the deliberately public passphrase `preview` whose hash is
+  committed in `playwright.config.ts`; it gates nothing outside local and CI
+  web servers.
+
+## Parity evidence (recorded parity session, this workstation)
+
+- ESLint: 0 errors. `tsc --noEmit`: clean. Production build: clean.
+- Unit: **30/30**, including four new verifier contracts (fail-closed on
+  missing and malformed config — which caught a real off-by-one in the hash
+  parser during development — correct/wrong verification, and the dev-hash
+  binding to exactly `preview`).
+- Full Playwright: recorded in the close-out commit — includes the updated
+  invited-access notice contract, the passphrase-carrying sign-in helper, a
+  new wrong-passphrase rejection contract (API 401 for wrong and bodiless
+  requests; UI inline alert, signed out, no pricing), and the unchanged
+  WEB-039 boundary contracts.
+
+## Production verification (two states, drivers committed)
+
+- `production-check.mjs --state unconfigured` — after the merge deploys and
+  before the steward sets the secret: session 503 with the honest error,
+  portal 401 without a token, invited-access notice live.
+- `production-check.mjs --state configured` — after the steward runs
+  `scripts/set-distributor-access.mjs --apply` (authenticated via `aws login`)
+  and redeploys: wrong and bodiless requests 401, UI inline rejection, portal
+  401 without a token. The positive case — the real passphrase entering — is
+  confirmed by the steward in a browser and recorded here; automation never
+  holds the passphrase.
+
+final result: pending release — all local gates passed

--- a/specs/proofs/web/WEB-040/production-check.mjs
+++ b/specs/proofs/web/WEB-040/production-check.mjs
@@ -1,0 +1,74 @@
+// WEB-040 production verification driver.
+//
+// Run from apps/web (copy in, run, remove — see WEB-039 pattern):
+//   CHECK_OUT=<proof dir> node ./pc-tmp.mjs [--state unconfigured|configured]
+//
+// Two-state verification:
+//   unconfigured (post-merge, before the steward sets the secret):
+//     session POST -> 503 with the honest not-configured error; sign-in page
+//     shows the invited-access notice.
+//   configured (after the steward sets DISTRIBUTOR_ACCESS_HASH + redeploy):
+//     wrong passphrase -> 401 (API and UI inline error); portal dataset stays
+//     401 without a token. The POSITIVE case — the real passphrase entering —
+//     is confirmed by the steward in a browser and recorded in the proof
+//     README; the passphrase is never given to automation.
+import { chromium } from '@playwright/test';
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BASE = process.env.CHECK_BASE || 'https://www.finspeed.online';
+const OUT = process.env.CHECK_OUT || path.dirname(fileURLToPath(import.meta.url));
+const state = process.argv.includes('--state')
+  ? process.argv[process.argv.indexOf('--state') + 1]
+  : 'configured';
+const results = [];
+const record = (name, ok, detail = '') => {
+  results.push({ name, ok, detail: String(detail).slice(0, 200) });
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${detail ? ' — ' + String(detail).slice(0, 120) : ''}`);
+};
+
+const post = (body) => fetch(`${BASE}/api/distributor/session`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+if (state === 'unconfigured') {
+  const response = await post({ passphrase: 'anything' });
+  const body = await response.json().catch(() => ({}));
+  record('unconfigured deployment refuses sessions with 503', response.status === 503, `status=${response.status}`);
+  record('503 carries the honest not-configured error', String(body.error || '').includes('not configured'), body.error);
+} else {
+  const wrong = await post({ passphrase: `definitely-wrong-${Math.random().toString(36).slice(2)}` });
+  record('wrong passphrase is rejected with 401', wrong.status === 401, `status=${wrong.status}`);
+  const bodiless = await fetch(`${BASE}/api/distributor/session`, { method: 'POST' });
+  record('bodiless session request is rejected with 401', bodiless.status === 401, `status=${bodiless.status}`);
+}
+
+{
+  const portal = await fetch(`${BASE}/api/distributor/portal`);
+  record('portal dataset stays 401 without a token', portal.status === 401, `status=${portal.status}`);
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  await page.addInitScript(() => window.localStorage.setItem('finspeed-consent', 'denied'));
+  await page.goto(`${BASE}/distributor/sign-in`, { waitUntil: 'networkidle', timeout: 45000 });
+  const notice = await page.getByText(/Access is limited to invited partners and the passphrase is verified/i)
+    .waitFor({ state: 'visible', timeout: 15000 }).then(() => true).catch(() => false);
+  record('sign-in shows the invited-access notice', notice);
+  if (state === 'configured') {
+    await page.getByLabel('Dealer ID or email').fill('probe@example.com');
+    await page.getByLabel('Access passphrase').fill('definitely-wrong-passphrase');
+    await page.getByRole('button', { name: 'Enter portal' }).click();
+    const rejected = await page.getByRole('alert').waitFor({ state: 'visible', timeout: 15000 }).then(() => true).catch(() => false);
+    record('UI rejects a wrong passphrase inline and stays signed out', rejected && page.url().includes('/distributor/sign-in'));
+  }
+  await page.screenshot({ path: path.join(OUT, `production-signin-${state}.png`) });
+  await browser.close();
+}
+
+writeFileSync(path.join(OUT, `production-results-${state}.json`), JSON.stringify({ base: BASE, state, when: new Date().toISOString(), results }, null, 2) + '\n');
+const failed = results.filter((r) => !r.ok);
+console.log(`\nRESULT (${state}): ${failed.length === 0 ? 'PASS' : 'FAIL'} — ${results.length - failed.length}/${results.length} pass`);
+process.exit(failed.length === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

**WEB-040** — the honest authentication step chosen by the steward while dealer accounts don't yet exist as a business fact: one invitation passphrase, verified server-side at the WEB-039 session seam.

- `POST /api/distributor/session` now verifies an scrypt-hashed passphrase (`DISTRIBUTOR_ACCESS_HASH`, timing-safe, 300ms failure delay): **503 fail-closed when unconfigured**, 401 with inline UI rejection when wrong, token when right.
- Steward-run `scripts/set-distributor-access.mjs`: hidden input, 12-char floor, fresh salt; `--apply` **fetches and merges** the Amplify env map (keys logged, values never) — the app carries pre-existing sensitive vars. Plaintext never reaches the repo, logs, or automation.
- Sign-in copy updated to the new truth — a deliberate WEB-036 contract change, since "credentials are not verified" becomes false: invited access, verified passphrase, unlinked dealer IDs, sample data.
- Dev/CI passphrase is the deliberately public `preview` (hash committed in the Playwright config; gates nothing real).

## Gates

ESLint 0 errors · tsc clean · unit **30/30** (new verifier contracts caught a real hash-parser off-by-one during development) · Playwright **77/77** · build clean.

**Merging deploys the fail-closed state**: production sign-in will honestly refuse ("access is not configured") until the steward runs the script and redeploys — never silently open. Two-state production verification drivers are committed in the proof; close follows the WEB-038/039 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)