### PR TITLE
fix(web): WEB-040 hand the access hash to the server runtime at build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,27 @@
+version: 1
+applications:
+  - appRoot: apps/web
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - nvm install 22
+            - nvm use 22
+            - npm ci
+        build:
+          commands:
+            # Amplify environment variables exist only at build time; the
+            # Next.js server runtime reads .env.production, so hand over the
+            # distributor access hash here (server-only, never NEXT_PUBLIC_).
+            # Absent variable (CI, previews, local) is a no-op and the portal
+            # stays honestly fail-closed (WEB-040).
+            - env | grep -E '^DISTRIBUTOR_ACCESS_HASH=' >> .env.production || true
+            - npm run build
+      artifacts:
+        baseDirectory: .next
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - ../../node_modules/**/*
+          - .next/cache/**/*

--- a/specs/contracts/web/json/spec.json
+++ b/specs/contracts/web/json/spec.json
@@ -974,7 +974,8 @@
         "specs/notes/indexes/**",
         "specs/project-progress/**",
         "specs/working-memory/**",
-        "design-qa.md"
+        "design-qa.md",
+        "amplify.yml"
       ]
     }
   ]

--- a/specs/notes/plans/web/WEB-040.md
+++ b/specs/notes/plans/web/WEB-040.md
@@ -63,3 +63,18 @@
       wrong passphrase rejected; steward confirms the real passphrase enters.
 - [ ] Telemetry refreshed.
 - [ ] Slice parked.
+
+## 2026-07-27 delivery discovery: build-time env vs server runtime
+
+- Amplify release job 410 succeeded with `DISTRIBUTOR_ACCESS_HASH` merged at
+  the app level, yet production stayed in the 503 unconfigured state: Amplify
+  environment variables exist at build time only, and the WEB_COMPUTE Next.js
+  server runtime does not inherit them.
+- Fix: the WEB-022 console buildspec moves into the repository as
+  `amplify.yml`, replicated verbatim plus one line that writes
+  `DISTRIBUTOR_ACCESS_HASH` into `.env.production` during the build — the
+  documented Amplify pattern for handing variables to server-side runtimes.
+  The value piped is the scrypt hash, server-only, never `NEXT_PUBLIC_`.
+- When the variable is absent (CI, local, previews) the pipe is a no-op and
+  the fail-closed 503 behaviour stands. The slice allow list gains
+  `amplify.yml`; recorded here as discovered scope.


### PR DESCRIPTION
## Summary

Release job 410 proved the delivery gap: the merged `DISTRIIBUTOR_ACCESS_HASH` app variable never reached the WEB_COMPUTE Next.js server runtime — Amplify env vars are build-time only — so production stayed in the honest 503 state after the steward set the secret. The WEB-022 console buildspec moves into the repo verbatim as `amplify.yml`, with one added build line writing the hash into `.env.production` (the documented Amplify pattern for server-side runtimes; server-only, never `NEXT_PUBLIC_`; a no-op wherever the variable is absent, preserving fail-closed CI/preview behaviour). Discovery and scope extension recorded in the WEB-040 plan.

Merging deploys; the next auto-build should flip the wrong-passphrase probe from 503 to 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)