### PR TITLE
fix(web): WEB-040 read the access hash through a literal env reference

### DIFF
--- a/apps/web/src/server/distributor-access.js
+++ b/apps/web/src/server/distributor-access.js
@@ -10,8 +10,14 @@ import { scryptSync, timingSafeEqual } from 'node:crypto';
 
 const ENV_KEY = 'DISTRIBUTOR_ACCESS_HASH';
 
-export function accessConfiguration(env = process.env) {
-  const raw = env[ENV_KEY];
+export function accessConfiguration(env) {
+  // The literal `process.env.DISTRIBUTOR_ACCESS_HASH` matters: Next.js inlines
+  // only literal references into the server bundle at build time, and the
+  // Amplify compute runtime does not receive .env.production (it lives outside
+  // the deployed .next artifact). A dynamic `env[ENV_KEY]` lookup silently
+  // resolved to undefined in production — WEB-040 build log 413. Tests still
+  // inject an explicit env object.
+  const raw = env ? env[ENV_KEY] : process.env.DISTRIBUTOR_ACCESS_HASH;
   if (!raw) return { configured: false };
   const parts = raw.split('$');
   if (parts.length !== 6 || parts[0] !== 'scrypt') return { configured: false, malformed: true };
@@ -28,7 +34,9 @@ export function accessConfiguration(env = process.env) {
   }
 }
 
-export function verifyAccessPassphrase(passphrase, env = process.env) {
+export function verifyAccessPassphrase(passphrase, env) {
+  // Pass `env` through undefined so accessConfiguration takes the inlinable
+  // literal path in production (see the note there); tests inject explicitly.
   const config = accessConfiguration(env);
   if (!config.configured) return { ok: false, configured: false };
   if (typeof passphrase !== 'string' || passphrase.length === 0 || passphrase.length > 256) {


### PR DESCRIPTION
## Summary

The last blocker on WEB-040's production verification. Build log 413 showed the buildspec pipe executing and Next.js loading `.env.production` — yet the runtime still reported unconfigured (honest 503). Cause: `distributor-access.js` read `env[ENV_KEY]` **dynamically**, and Next.js inlines only *literal* `process.env.NAME` references into the server bundle at build time; `.env.production` itself lives outside the deployed `.next` artifact, so nothing supplied the value at runtime either.

Both entry points now take the literal path when no env object is injected (tests inject explicitly, so all contracts are unchanged).

Gates: unit 30/30 · Playwright 77/77 · lint 0 errors · typecheck clean · build clean.

After merge: Amplify rebuild, then a wrong-passphrase probe returning **401 instead of 503** confirms verification is finally live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)