### PR TITLE
feat(web): WEB-041 publish privacy, terms, refunds and shipping policies

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -199,3 +199,54 @@ a {
     opacity: 0.8;
   }
 }
+
+/* WEB-041 legal & policy pages — server-rendered outside the design SPA so
+   they stay readable without JavaScript for gateway review and crawlers. */
+.legal-page {
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  color: #16181d;
+  background: #fbfbf9;
+  font: 400 1rem/1.7 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+.legal-page__brand {
+  display: inline-block;
+  font: 700 1.05rem/1 ui-sans-serif, system-ui, sans-serif;
+  letter-spacing: 0.14em;
+  color: #16181d;
+  text-decoration: none;
+  margin-bottom: 2.25rem;
+}
+.legal-page__eyebrow {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #0f7f96;
+  margin: 0 0 0.5rem;
+}
+.legal-page h1 { font-size: clamp(1.9rem, 4vw, 2.6rem); line-height: 1.1; margin: 0 0 0.75rem; }
+.legal-page__intro { font-size: 1.06rem; color: #3d434d; margin: 0 0 0.75rem; }
+.legal-page__meta { font-size: 0.85rem; color: #6b7280; margin: 0 0 2.5rem; }
+.legal-page__section { margin-bottom: 2.25rem; }
+.legal-page__section h2 {
+  font-size: 1.16rem;
+  line-height: 1.3;
+  margin: 0 0 0.6rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid #e3e3de;
+}
+.legal-page__section p, .legal-page__section li { color: #2b3038; }
+.legal-page__section ul { padding-left: 1.15rem; margin: 0.5rem 0; }
+.legal-page__section li { margin-bottom: 0.4rem; }
+.legal-page a { color: #0f7f96; }
+.legal-page__footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e3e3de; font-size: 0.9rem; color: #6b7280; }
+.legal-page__footer ul { list-style: none; display: flex; flex-wrap: wrap; gap: 1.15rem; padding: 0; margin: 0 0 1rem; }
+@media (prefers-color-scheme: dark) {
+  .legal-page { background: #0d0f12; color: #e8eaed; }
+  .legal-page__brand { color: #e8eaed; }
+  .legal-page__intro { color: #b7bcc4; }
+  .legal-page__section p, .legal-page__section li { color: #ced2d8; }
+  .legal-page__section h2, .legal-page__footer { border-color: #24272c; }
+  .legal-page a, .legal-page__eyebrow { color: #4fd2e8; }
+}

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from 'next';
+import { LegalPage, Section } from '@/components/legal-page';
+
+export const metadata: Metadata = {
+  title: 'Finspeed — Privacy policy',
+  description: 'How Finspeed collects, uses, stores and protects personal information, and the choices available to you.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage
+      title="Privacy policy"
+      intro="This policy explains what information Finspeed collects when you use finspeed.online, why we collect it, and the control you have over it."
+    >
+      <Section heading="Information we collect">
+        <p>We collect only what a request or order needs:</p>
+        <ul>
+          <li><strong>Information you give us</strong> — name, email address, phone number, and delivery or billing address when you place an order, request a custom build, or contact support.</li>
+          <li><strong>Business information</strong> — for distributor enquiries, your business name, GSTIN, and contact details.</li>
+          <li><strong>Analytics</strong> — anonymised usage events, and only after you accept analytics in the consent banner. Decline and no analytics events are sent.</li>
+          <li><strong>Local browser storage</strong> — your cart, saved build configuration, and theme preference are stored in your browser. They are not transmitted to us until you submit an order or request.</li>
+        </ul>
+      </Section>
+
+      <Section heading="How we use it">
+        <p>To fulfil and support orders and custom-build requests, to answer enquiries, to arrange delivery and warranty service, to meet tax and accounting obligations, and — where you have consented — to understand how the site is used so we can improve it. We do not sell personal information.</p>
+      </Section>
+
+      <Section heading="Sharing">
+        <p>We share information only with parties that help us deliver the service: payment processors, logistics and delivery partners, and authorised Finspeed dealers handling your order or service request. Each receives only what their task requires. We also disclose information where the law requires it.</p>
+      </Section>
+
+      <Section heading="Payments">
+        <p>Card, UPI and netbanking details are entered directly with our payment provider and are never received or stored on Finspeed systems. We retain only the transaction reference and status needed to service your order.</p>
+      </Section>
+
+      <Section heading="Retention">
+        <p>Order and invoice records are retained as long as tax and accounting law requires. Enquiry and support correspondence is kept only as long as needed to resolve the matter and any follow-up. Analytics data is retained in aggregate.</p>
+      </Section>
+
+      <Section heading="Your choices">
+        <ul>
+          <li>Accept or decline analytics at any time through the consent banner; a declined choice is remembered and honoured on later visits.</li>
+          <li>Request a copy, correction, or deletion of the personal information we hold about you.</li>
+          <li>Ask us to stop contacting you about anything other than an order already in progress.</li>
+        </ul>
+        <p>To exercise any of these, contact us using the details on our contact page. We respond within a reasonable period and will confirm what action we have taken.</p>
+      </Section>
+
+      <Section heading="Security">
+        <p>The site is served over HTTPS, dealer pricing and portal records are held behind a server boundary rather than in the public browser bundle, and access to customer data is limited to staff who need it. No system is perfectly secure, and we will tell affected people promptly if a breach materially affects them.</p>
+      </Section>
+
+      <Section heading="Children">
+        <p>Finspeed does not knowingly collect personal information from children. Purchases of bicycles sized for children are made by an adult, whose details we hold.</p>
+      </Section>
+
+      <Section heading="Changes and contact">
+        <p>If this policy changes materially we will update the date above and, where the change affects existing orders, tell affected customers directly. Questions about this policy, or about the information we hold, should go to the contact details on our contact page.</p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/apps/web/src/app/refunds/page.tsx
+++ b/apps/web/src/app/refunds/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next';
+import { LegalPage, Section } from '@/components/legal-page';
+
+export const metadata: Metadata = {
+  title: 'Finspeed — Returns & refunds',
+  description: 'Finspeed returns, cancellation and refund policy, including transit damage, warranty claims and refund timelines.',
+};
+
+export default function RefundsPage() {
+  return (
+    <LegalPage
+      title="Returns & refunds"
+      intro="What you can return, how to raise a claim, and when to expect a refund."
+    >
+      <Section heading="Cancellations">
+        <p>An order can be cancelled at no cost any time before it is dispatched — contact us with your order reference. Once a bicycle has been dispatched, cancellation is handled as a return under the terms below.</p>
+      </Section>
+
+      <Section heading="Damage in transit">
+        <p>Report transit damage within <strong>48 hours</strong> of delivery, with photographs of the packaging and the bicycle. Confirmed transit damage is replaced or refunded in full at no cost to you, including return collection.</p>
+      </Section>
+
+      <Section heading="Returns">
+        <ul>
+          <li>Unused bicycles in their original packaging may be returned within <strong>7 days</strong> of delivery.</li>
+          <li>The bicycle must be unridden and complete, with all accessories, documentation and fittings included.</li>
+          <li>Return shipping is payable by you unless the return is due to damage, a defect, or our error.</li>
+          <li>Assembled, used, or customer-customised bicycles cannot be returned except under warranty.</li>
+        </ul>
+      </Section>
+
+      <Section heading="Custom builds">
+        <p>Custom build requests are quoted and confirmed with you before any payment is taken. Because they are prepared to your specification, a confirmed custom build cannot be returned for change of mind — warranty and transit-damage protections still apply in full.</p>
+      </Section>
+
+      <Section heading="Warranty claims">
+        <p>Frames carry a five-year structural warranty and components twelve months, from the date of delivery. Warranty covers manufacturing defects; it does not cover wear, accident damage, or damage from misuse or unauthorised modification. Raise a claim with your order reference, the model and variant, and photographs of the issue.</p>
+      </Section>
+
+      <Section heading="How to raise a return or claim">
+        <p>Contact us with your order reference and a description of the issue, with photographs where relevant. We confirm the outcome and, where a return is approved, arrange collection or give you a return address.</p>
+      </Section>
+
+      <Section heading="Refund timelines">
+        <p>Approved refunds are issued to the original payment method. Refunds are initiated within <strong>5 working days</strong> of the returned bicycle being received and inspected, or of a transit-damage claim being confirmed. Your bank or card issuer may take a further 5–10 working days to credit the amount. We confirm by email when a refund has been initiated.</p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/apps/web/src/app/shipping/page.tsx
+++ b/apps/web/src/app/shipping/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next';
+import { LegalPage, Section } from '@/components/legal-page';
+
+export const metadata: Metadata = {
+  title: 'Finspeed — Shipping policy',
+  description: 'How Finspeed dispatches, delivers and tracks bicycles, including timelines, charges and delivery checks.',
+};
+
+export default function ShippingPage() {
+  return (
+    <LegalPage
+      title="Shipping policy"
+      intro="How and when your bicycle reaches you, and what to check when it arrives."
+    >
+      <Section heading="Dispatch">
+        <p>Orders are dispatched ex-works from Greater Noida, Uttar Pradesh. In-stock bicycles are typically dispatched within <strong>3–5 working days</strong> of payment confirmation. Custom builds are dispatched to the timeline confirmed in your quote. We tell you the dispatch date and tracking details by email.</p>
+      </Section>
+
+      <Section heading="Delivery timelines">
+        <p>Delivery is typically <strong>3–7 working days</strong> after dispatch within India, depending on destination. Remote and hill destinations may take longer. These are estimates from our logistics partners, not guarantees; we keep you informed if a consignment is delayed.</p>
+      </Section>
+
+      <Section heading="Charges">
+        <p>Shipping charges are shown before payment and depend on destination and consignment size. Where an order qualifies for free delivery, that is stated at checkout. Distributor consignments ship on the terms in your dealer agreement.</p>
+      </Section>
+
+      <Section heading="Delivery and inspection">
+        <ul>
+          <li>Someone aged 18 or over must be available to receive the consignment.</li>
+          <li>Inspect the packaging before signing. If it is visibly damaged, note this on the delivery receipt and photograph it.</li>
+          <li>Report any transit damage within <strong>48 hours</strong> — see our returns and refunds policy.</li>
+        </ul>
+      </Section>
+
+      <Section heading="Assembly">
+        <p>Bicycles ship partly assembled and require final assembly — handlebars, front wheel, pedals and seat height — before riding. Our assembly guide covers the steps. If you would prefer a professional build, an authorised Finspeed dealer can complete it; the dealer locator lists nearby locations.</p>
+      </Section>
+
+      <Section heading="Address changes and failed delivery">
+        <p>Tell us before dispatch if your address changes; afterwards we can only request redirection through the carrier and cannot guarantee it. If delivery fails because nobody is available or the address is incorrect, we contact you to arrange redelivery; repeated failed attempts may incur a further shipping charge.</p>
+      </Section>
+
+      <Section heading="Serviceable areas">
+        <p>We currently deliver within India. For enquiries about destinations we do not yet serve, contact us and we will tell you what is possible.</p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next';
+import { LegalPage, Section } from '@/components/legal-page';
+
+export const metadata: Metadata = {
+  title: 'Finspeed — Terms of service',
+  description: 'The terms on which Finspeed sells bicycles and provides finspeed.online, including orders, pricing, warranty and liability.',
+};
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Terms of service"
+      intro="These terms govern your use of finspeed.online and any order you place through it."
+    >
+      <Section heading="Who we are">
+        <p>Finspeed designs and sells bicycles from Greater Noida, Uttar Pradesh, India, and supplies them directly and through authorised dealers. Using this site means you accept these terms.</p>
+      </Section>
+
+      <Section heading="Orders">
+        <p>An order placed on the site is an offer to buy. It is accepted when we confirm dispatch. We may decline an order — for example where a bicycle is unavailable, a price or specification is shown in error, or we cannot deliver to the address given — and any payment taken for a declined order is refunded in full.</p>
+      </Section>
+
+      <Section heading="Custom builds">
+        <p>Configurations outside our catalogue specification are handled as custom build requests, not immediate purchases. We confirm compatibility, appearance, availability and final price with you before any payment is taken. Preview imagery for uncatalogued combinations is a reference, not a guarantee of exact appearance.</p>
+      </Section>
+
+      <Section heading="Pricing and payment">
+        <p>Prices are in Indian Rupees and include applicable taxes unless stated otherwise. Shipping charges are shown before payment. We may change prices at any time, but never after accepting your order. Payment is processed by our payment provider; we do not receive or store your card details.</p>
+      </Section>
+
+      <Section heading="Product information">
+        <p>We work to describe models, specifications and finishes accurately. Photography is representative; colour reproduction varies between screens, and components may change where a supplier part is superseded by an equivalent or better one. Where a specification is provisional we say so on the product.</p>
+      </Section>
+
+      <Section heading="Delivery, returns and warranty">
+        <p>Delivery is covered by our shipping policy. Cancellations, returns, refunds and warranty claims are covered by our returns and refunds policy. Both form part of these terms.</p>
+      </Section>
+
+      <Section heading="Safe use">
+        <p>Bicycles ship partly assembled and must be correctly assembled and checked before riding. Ride within your ability and the law, and wear appropriate protective equipment. We are not responsible for injury or damage arising from incorrect assembly, unauthorised modification, inadequate maintenance, or use beyond the intended purpose of the bicycle.</p>
+      </Section>
+
+      <Section heading="Distributor portal">
+        <p>The distributor portal is for invited partners. Access credentials are personal to your business and must not be shared. Pricing and account information shown there is confidential and provided for your business use only.</p>
+      </Section>
+
+      <Section heading="Site availability and content">
+        <p>We aim to keep the site available but do not guarantee uninterrupted access, and we may change or withdraw features. Site content, imagery and branding belong to Finspeed and may not be reproduced commercially without permission.</p>
+      </Section>
+
+      <Section heading="Liability">
+        <p>Nothing in these terms limits liability that cannot be limited by law, including for death or personal injury caused by our negligence, or for fraud. Subject to that, our liability for any order is limited to the amount you paid for it.</p>
+      </Section>
+
+      <Section heading="Governing law and changes">
+        <p>These terms are governed by the laws of India and disputes are subject to the courts of Uttar Pradesh. We may update these terms; the version in force when you place an order is the one that applies to it.</p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/apps/web/src/components/legal-page.tsx
+++ b/apps/web/src/components/legal-page.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+// Legal and policy pages are deliberately server-rendered outside the design
+// SPA (WEB-041): payment-gateway reviewers, regulators and crawlers must be
+// able to read them without JavaScript. Chrome is intentionally minimal and
+// self-contained for the same reason.
+
+export const LEGAL_ROUTES = [
+  { href: '/privacy', label: 'Privacy policy' },
+  { href: '/terms', label: 'Terms of service' },
+  { href: '/refunds', label: 'Returns & refunds' },
+  { href: '/shipping', label: 'Shipping policy' },
+] as const;
+
+export const LAST_UPDATED = '27 July 2026';
+
+export function LegalPage({ title, intro, children }: { title: string; intro: string; children: ReactNode }) {
+  return (
+    <main className="legal-page">
+      <header className="legal-page__header">
+        <Link href="/" className="legal-page__brand">FINSPEED</Link>
+        <p className="legal-page__eyebrow">Policies</p>
+        <h1>{title}</h1>
+        <p className="legal-page__intro">{intro}</p>
+        <p className="legal-page__meta">Last updated {LAST_UPDATED}</p>
+      </header>
+
+      <div className="legal-page__body">{children}</div>
+
+      <footer className="legal-page__footer">
+        <nav aria-label="Policies">
+          <ul>
+            {LEGAL_ROUTES.map((route) => (
+              <li key={route.href}><Link href={route.href}>{route.label}</Link></li>
+            ))}
+            <li><Link href="/contact">Contact us</Link></li>
+          </ul>
+        </nav>
+        <p>
+          Finspeed · Greater Noida, Uttar Pradesh, India ·{' '}
+          <Link href="/">Back to the storefront</Link>
+        </p>
+      </footer>
+    </main>
+  );
+}
+
+export function Section({ heading, children }: { heading: string; children: ReactNode }) {
+  return (
+    <section className="legal-page__section">
+      <h2>{heading}</h2>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/tests/legal-pages.spec.ts
+++ b/apps/web/tests/legal-pages.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+
+// WEB-041: policy pages must be readable by payment-gateway reviewers,
+// regulators and crawlers — which means server-rendered, no JavaScript needed.
+const PAGES = [
+  { path: '/privacy', title: 'Finspeed — Privacy policy', heading: 'Privacy policy', marker: 'consent banner' },
+  { path: '/terms', title: 'Finspeed — Terms of service', heading: 'Terms of service', marker: 'Governing law' },
+  { path: '/refunds', title: 'Finspeed — Returns & refunds', heading: 'Returns & refunds', marker: '5 working days' },
+  { path: '/shipping', title: 'Finspeed — Shipping policy', heading: 'Shipping policy', marker: 'Greater Noida' },
+];
+
+test.describe('WEB-041 legal and policy pages', () => {
+  for (const page_ of PAGES) {
+    test(`${page_.path} is server-rendered with its own metadata`, async ({ page }) => {
+      const response = await page.goto(page_.path);
+      expect(response?.status()).toBe(200);
+      await expect(page).toHaveTitle(page_.title);
+      await expect(page.getByRole('heading', { level: 1, name: page_.heading })).toBeVisible();
+      await expect(page.locator('main')).toContainText(page_.marker);
+    });
+  }
+
+  test('policies are readable with JavaScript disabled', async ({ browser }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+    for (const page_ of PAGES) {
+      await page.goto(page_.path);
+      await expect(page.getByRole('heading', { level: 1, name: page_.heading })).toBeVisible();
+      await expect(page.locator('main')).toContainText(page_.marker);
+    }
+    await context.close();
+  });
+
+  test('every policy cross-links the others and contact', async ({ page }) => {
+    await page.goto('/privacy');
+    const nav = page.getByRole('navigation', { name: 'Policies' });
+    for (const label of ['Privacy policy', 'Terms of service', 'Returns & refunds', 'Shipping policy', 'Contact us']) {
+      await expect(nav.getByRole('link', { name: label })).toBeVisible();
+    }
+  });
+});

--- a/specs/contracts/web/json/spec.json
+++ b/specs/contracts/web/json/spec.json
@@ -977,6 +977,26 @@
         "design-qa.md",
         "amplify.yml"
       ]
+    },
+    {
+      "id": "WEB-041",
+      "title": "Legal and policy pages",
+      "done_definition": [
+        "Privacy, terms, returns/refunds and shipping policies are served as static server-rendered routes readable without JavaScript",
+        "Each carries its own metadata and cross-links to the others and to contact",
+        "The consent banner's missing privacy link (WEB-036 follow-up) is satisfiable",
+        "Content is business-accurate where verifiable and flagged for steward legal review before gateway submission"
+      ],
+      "allow": [
+        "apps/web/**",
+        "specs/contracts/web/**",
+        "specs/notes/plans/web/WEB-041.md",
+        "specs/proofs/web/WEB-041/**",
+        "specs/notes/indexes/**",
+        "specs/project-progress/**",
+        "specs/working-memory/**",
+        "design-qa.md"
+      ]
     }
   ]
 }

--- a/specs/notes/plans/web/WEB-041.md
+++ b/specs/notes/plans/web/WEB-041.md
@@ -1,0 +1,46 @@
+# Plan — WEB-041
+
+- Context:
+  The steward is opening a Razorpay merchant account to make the storefront
+  transact. Gateway approval requires the privacy, terms, refund and shipping
+  policies to be live and reachable on the domain — none existed. WEB-036 also
+  recorded a missing `/privacy` route that the consent banner should link to.
+  This slice is therefore both a commercial prerequisite and the closure of a
+  standing follow-up, and it ships before any payment code exists.
+- Goals:
+  - Publish privacy, terms of service, returns & refunds, and shipping policies
+    as static, server-rendered routes that read without JavaScript.
+  - Give each its own title and description metadata, and cross-link all four
+    plus contact so a reviewer can navigate the set.
+  - Keep content business-accurate where the repository verifies it, and flag
+    for steward legal review everything that is a reasonable default rather
+    than a confirmed business fact.
+- Risks:
+  - Policy text is drafted, not legally reviewed. It states timelines and terms
+    that bind the business; the steward must confirm or amend every figure
+    before submitting to a gateway. Recorded prominently in the proof.
+  - Registered entity name, address and GSTIN are not in the repository, so the
+    pages carry only the verifiable "Finspeed · Greater Noida" line; gateways
+    usually require full entity details, which the steward must add.
+  - Rendering outside the design SPA means these pages do not carry the
+    editorial header and footer; deliberate, because no-JavaScript readability
+    matters more here than visual continuity.
+
+## Steps
+1. Add a self-contained `LegalPage` component with minimal branded chrome and
+   a cross-link footer.
+2. Add `/privacy`, `/terms`, `/refunds`, `/shipping` as static Next routes with
+   per-route metadata.
+3. Style them in `globals.css` with light and dark support.
+4. Cover with contract tests including a JavaScript-disabled pass.
+
+## Execution Checklist
+- [x] Four policy routes prerender as static pages with their own metadata.
+- [x] Contract tests green, including the JavaScript-disabled read.
+- [x] Lint 0 errors, typecheck clean, production build clean.
+- [ ] Steward legal review of the drafted terms and timelines.
+- [ ] Entity details (registered name, address, GSTIN) added before gateway
+      submission.
+- [ ] Consent banner and storefront footer linked to `/privacy` (follow-up).
+- [ ] Telemetry refreshed.
+- [ ] Slice parked.

--- a/specs/project-progress/slice-ledger.json
+++ b/specs/project-progress/slice-ledger.json
@@ -251,6 +251,12 @@
           "domain": "web",
           "title": "Invited-access verification for the distributor portal",
           "status": "active"
+        },
+        {
+          "id": "WEB-041",
+          "domain": "web",
+          "title": "Legal and policy pages",
+          "status": "active"
         }
       ]
     }

--- a/specs/proofs/web/WEB-041/README.md
+++ b/specs/proofs/web/WEB-041/README.md
@@ -1,0 +1,42 @@
+# WEB-041 Proof - Legal and policy pages
+
+## Steward action required before gateway submission
+
+The policy text is **drafted, not legally reviewed**. It commits the business
+to specific terms — a 7-day return window, 48-hour transit-damage reporting,
+5 working days to initiate refunds, 3-5 day dispatch and 3-7 day delivery, and
+a five-year frame / twelve-month component warranty. Those figures were chosen
+as reasonable defaults consistent with the distributor FAQ already in the
+repository. **Confirm or amend each before submitting to Razorpay**, and add
+the registered entity name, address and GSTIN, which the repository does not
+contain and the pages therefore omit.
+
+## What shipped
+
+- `/privacy`, `/terms`, `/refunds`, `/shipping` — static server-rendered
+  routes, each with its own title and description metadata, cross-linking the
+  other three plus `/contact`.
+- Deliberately rendered outside the design SPA: gateway reviewers, regulators
+  and crawlers must be able to read them with JavaScript disabled, which the
+  client-only SPA cannot guarantee. The trade-off is that they carry minimal
+  branded chrome rather than the editorial header and footer.
+- Light and dark styling via `prefers-color-scheme`.
+
+## Verification
+
+- Production build: all four routes listed as `○ (Static)` prerendered.
+- `apps/web/tests/legal-pages.spec.ts`: **6/6** — per-route status, title,
+  heading and content markers; a **JavaScript-disabled** pass over all four;
+  and the cross-link set.
+- Lint 0 errors (a `react/no-unescaped-entities` error found and fixed during
+  development), typecheck clean, unit suite 30/30 unaffected.
+
+## Follow-ups recorded
+
+- Link `/privacy` from the consent banner (closes the WEB-036 follow-up) and
+  from the storefront footer; both live inside the design SPA and are a
+  separate, small slice.
+- Commerce sequence continues per the roadmap: order persistence, then the
+  Razorpay integration with server-side webhook verification.
+
+final result: passed — pages live and tested; steward legal review outstanding


### PR DESCRIPTION
## Summary

First slice of the commerce roadmap, and the **prerequisite for your Razorpay merchant application** — gateways require these policies live and reachable before approving an account. Also closes WEB-036's recorded missing `/privacy` route.

- `/privacy`, `/terms`, `/refunds`, `/shipping` — static server-rendered routes, each with its own metadata, cross-linking each other and `/contact`.
- **Deliberately outside the design SPA**: reviewers, regulators and crawlers must read these without JavaScript, which a client-only SPA can't guarantee. A contract test verifies exactly that with `javaScriptEnabled: false`.
- Light and dark styling.

## ⚠️ Before you submit to Razorpay

The text is **drafted, not legally reviewed**. It commits the business to specific terms — 7-day returns, 48-hour damage reporting, 5-working-day refund initiation, 3–5 day dispatch, 3–7 day delivery, 5-year frame warranty — chosen as reasonable defaults consistent with the distributor FAQ already in the repo. **Confirm or amend each**, and add your registered entity name, address and GSTIN, which aren't in the repository so the pages omit them.

## Gates

New contract tests **6/6** (including the no-JavaScript pass) · lint 0 errors · typecheck clean · build clean, all four routes `○ (Static)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)